### PR TITLE
Fix missing include

### DIFF
--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 namespace toml
 {


### PR DESCRIPTION
I spotted this when compiling on OS X. Linux seems fine, for some reason.

The sstringstream is used on line 92 of this file:

```cpp
static unsigned int make_codepoint(string_type str)
    {
        unsigned int codepoint;
        std::basic_istringstream<value_type> iss(str);
        iss >> std::hex >> codepoint;
        return codepoint;
    }
```