### PR TITLE
Allow to build with intel c++ compiler

### DIFF
--- a/tests/test_parse_unicode.cpp
+++ b/tests/test_parse_unicode.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <fstream>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__INTEL_COMPILER)
 BOOST_AUTO_TEST_CASE(test_hard_example_unicode)
 {
     const auto data = toml::parse("toml/tests/hard_example_unicode.toml");

--- a/toml/exception.hpp
+++ b/toml/exception.hpp
@@ -9,7 +9,7 @@ namespace toml
 struct exception : public std::exception
 {
   public:
-    virtual ~exception() override = default;
+    virtual ~exception() noexcept override = default;
     virtual const char* what() const noexcept override {return "";}
 };
 
@@ -18,7 +18,7 @@ struct syntax_error : public toml::exception
   public:
     explicit syntax_error(const std::string& what_arg) : what_(what_arg){}
     explicit syntax_error(const char* what_arg)        : what_(what_arg){}
-    virtual ~syntax_error() override = default;
+    virtual ~syntax_error() noexcept override = default;
     virtual const char* what() const noexcept override {return what_.c_str();}
 
   protected:
@@ -30,7 +30,7 @@ struct type_error : public toml::exception
   public:
     explicit type_error(const std::string& what_arg) : what_(what_arg){}
     explicit type_error(const char* what_arg)        : what_(what_arg){}
-    virtual ~type_error() override = default;
+    virtual ~type_error() noexcept override = default;
     virtual const char* what() const noexcept override {return what_.c_str();}
 
   protected:
@@ -42,7 +42,7 @@ struct internal_error : public toml::exception
   public:
     explicit internal_error(const std::string& what_arg) : what_(what_arg){}
     explicit internal_error(const char* what_arg)        : what_(what_arg){}
-    virtual ~internal_error() override = default;
+    virtual ~internal_error() noexcept override = default;
     virtual const char* what() const noexcept override {return what_.c_str();}
   protected:
     std::string what_;

--- a/toml/from_toml.hpp
+++ b/toml/from_toml.hpp
@@ -86,7 +86,10 @@ struct from_toml_tie_impl
 
     static void invoke(std::tuple<Ts& ...> tie, const toml::value& v)
     {
-        if(type_index == v.type())
+        // static_cast is needed because with intel c++ compiler, operator==
+        // is only defined when the two types are strictly equal, and type_index
+        // is const toml::value_t, while v.type() is toml::value_t.
+        if(static_cast<toml::value_t>(type_index) == v.type())
         {
             from_toml(std::get<index>(tie), v);
             return;

--- a/toml/traits.hpp
+++ b/toml/traits.hpp
@@ -37,6 +37,12 @@ struct has_resize_method_impl
     template<typename T> static std::false_type check(...);
 };
 
+/// Intel C++ compiler can not use decltype in parent class declaration, here
+/// is a hack to work around it. https://stackoverflow.com/a/23953090/4692076
+#ifdef __INTEL_COMPILER
+#define decltype(...) std::enable_if<true, decltype(__VA_ARGS__)>::type
+#endif
+
 template<typename T>
 struct has_iterator    : decltype(has_iterator_impl::check<T>(nullptr)){};
 template<typename T>
@@ -47,6 +53,10 @@ template<typename T>
 struct has_mapped_type : decltype(has_mapped_type_impl::check<T>(nullptr)){};
 template<typename T>
 struct has_resize_method : decltype(has_resize_method_impl::check<T>(nullptr)){};
+
+#ifdef __INTEL_COMPILER
+#undef decltype(...)
+#endif
 
 template<typename T>
 struct is_container : std::integral_constant<bool,


### PR DESCRIPTION
Intel C++ compiler is not completely standard compliant, but only a few changes are needed to make the code build and the tests pass.

I ran the tests locally with icc version 14.0.2.

Adding this compiler to travis is [possible](https://github.com/nemequ/icc-travis), but a bit hard: you need to apply for an open source license, and then renew the license every year.