### PR TITLE
enable to get toml::value as toml::value

### DIFF
--- a/tests/test_get.cpp
+++ b/tests/test_get.cpp
@@ -116,6 +116,14 @@ BOOST_AUTO_TEST_CASE(test_get_exact)
         tab["key3"] = toml::value(123);
         BOOST_CHECK(tab == toml::get<toml::table>(v));
     }
+    {
+        toml::value v1(42);
+        BOOST_CHECK(v1 == toml::get<toml::value>(v1));
+
+        toml::value v2(54);
+        toml::get<toml::value>(v1) = v2;
+        BOOST_CHECK(v2 == toml::get<toml::table>(v1));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_get_integer_type)

--- a/tests/test_get.cpp
+++ b/tests/test_get.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(test_get_exact)
 
         toml::value v2(54);
         toml::get<toml::value>(v1) = v2;
-        BOOST_CHECK(v2 == toml::get<toml::table>(v1));
+        BOOST_CHECK(v2 == toml::get<toml::value>(v1));
     }
 }
 

--- a/toml/get.hpp
+++ b/toml/get.hpp
@@ -34,6 +34,30 @@ inline T&& get(value&& v)
 }
 
 // ============================================================================
+// T == toml::value; identity transformation.
+
+template<typename T, typename std::enable_if<
+    std::is_same<T, ::toml::value>::value, std::nullptr_t>::type = nullptr>
+inline T& get(value& v)
+{
+    return v;
+}
+
+template<typename T, typename std::enable_if<
+    std::is_same<T, ::toml::value>::value, std::nullptr_t>::type = nullptr>
+inline T const& get(const value& v)
+{
+    return v;
+}
+
+template<typename T, typename std::enable_if<
+    std::is_same<T, ::toml::value>::value, std::nullptr_t>::type = nullptr>
+inline T&& get(value&& v)
+{
+    return std::move(v);
+}
+
+// ============================================================================
 // integer convertible from toml::Integer
 
 template<typename T, typename std::enable_if<detail::conjunction<


### PR DESCRIPTION
In some cases, mostly with `toml::find`, we need to get an instance of `toml::value` to show a better error message.

```cpp
const auto  root = toml::parse(filename);
const auto& tab1 = toml::find<toml::table>(root, "table1", filename); // discarding region info
const auto& tab2 = toml::find<toml::table>(tab1, "table2", filename); // need filename
```

The above code shows an error message like the following when `table2` is missing.

```console
terminate called after throwing an instance of 'std::out_of_range'
  what():  [error] key "table2" not found in example.toml
```

But `table2` is defined inside `table1`, so the error message should be

```console
terminate called after throwing an instance of 'std::out_of_range'
  what():  [error] key "table2" not found
 --> example.toml
 3 | [table1]
   | ~~~~~~~ in this table
```

To show this, we need to write a code in this way.

```cpp
const auto  root = toml::parse(filename);
const auto& tab1 = toml::find<toml::value>(root, "table1", filename);
//                            ~~~~~~~~~~~ here, it should be toml::value that has region_info
const auto& tab2 = toml::find<toml::table>(tab1, "table2");
```

This code requires `toml::get<toml::value>`.

This PR enables to call `toml::get<toml::value>(toml::value <cv-qualifier> <ref-qualifier>)`.

