### PR TITLE
fix the error with BOM and end of file w/o newline

### DIFF
--- a/tests/test_parse_file.cpp
+++ b/tests/test_parse_file.cpp
@@ -194,3 +194,469 @@ BOOST_AUTO_TEST_CASE(test_hard_example)
     BOOST_CHECK(toml::get<std::vector<std::string>>(bit.at("multi_line_array")) ==
                 expected_multi_line_array);
 }
+
+// ---------------------------------------------------------------------------
+// after here, the test codes generate the content of a file.
+
+BOOST_AUTO_TEST_CASE(test_file_with_BOM)
+{
+    {
+        const std::string table(
+            "\xEF\xBB\xBF" // BOM
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss, "test_file_with_BOM.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "\xEF\xBB\xBF" // BOM
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss, "test_file_with_BOM_CRLF.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_file_without_newline_at_the_end_of_file)
+{
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\""
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_file_without_newline_at_the_end_of_file.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\""
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_file_without_newline_at_the_end_of_file_CRLF.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\" # comment"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_file_without_newline_at_the_end_of_file_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\" # comment"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_file_without_newline_at_the_end_of_file_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\" \t"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_file_without_newline_at_the_end_of_file_ws.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\" \t"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_file_without_newline_at_the_end_of_file_ws.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_files_end_with_comment)
+{
+    // comment w/o newline
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "# comment"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "# comment\n"
+            "# one more comment"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    // comment w/ newline
+
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "# comment\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "# comment\n"
+            "# one more comment\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    // CRLF version
+
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "# comment"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "# comment\r\n"
+            "# one more comment"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "# comment\r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "# comment\r\n"
+            "# one more comment\r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_comment.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_files_end_with_empty_lines)
+{
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "\n"
+            "\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    // with whitespaces
+
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "  \n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "  \n"
+            "  \n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "\n"
+            "  \n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "  \n"
+            "\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    // with whitespaces but no newline
+    {
+        const std::string table(
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            "  "
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+
+    // CRLF
+
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "\r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "\r\n"
+            "\r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+
+    // with whitespaces
+
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "  \r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "\r\n"
+            "  \r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "  \r\n"
+            "\r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "  \r\n"
+            "  \r\n"
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            "  "
+            );
+        std::istringstream iss(table);
+        const auto data = toml::parse(iss,
+                "test_files_end_with_newline.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+}

--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -1472,10 +1472,10 @@ inline table parse(std::istream& is, std::string fname = "unknown file")
     // be compared to char. However, since we are always out of luck, we need to
     // check our chars are equivalent to BOM. To do this, first we need to
     // convert char to unsigned char to guarantee the comparability.
-    if(letters.size() >= 3)
+    if(loc.source()->size() >= 3)
     {
         std::array<unsigned char, 3> BOM;
-        std::memcpy(BOM.data(), letters.data(), 3);
+        std::memcpy(BOM.data(), loc.source()->data(), 3);
         if(BOM[0] == 0xEF && BOM[1] == 0xBB && BOM[2] == 0xBF)
         {
             loc.iter() += 3; // BOM found. skip.


### PR DESCRIPTION
This PR fixes...
* finding and skipping BOM at the front of the file
* skipping lines at the end of a file that does not include newline but whitespaces
like:
```toml
key = "value"  # <- whitespace here
```
or
```toml
key = "value"
  # <- whitespace here
```

related to #16 .