### PR TITLE
add an extra parameter `hints` to format_error

### DIFF
--- a/toml/value.hpp
+++ b/toml/value.hpp
@@ -804,7 +804,8 @@ inline std::string format_error(const std::string& err_msg,
         const toml::value& v, const std::string& comment,
         std::vector<std::string> hints = {})
 {
-    return detail::format_underline(err_msg, detail::get_region(v), comment, hints);
+    return detail::format_underline(err_msg, detail::get_region(v), comment,
+                                    std::move(hints));
 }
 
 inline std::string format_error(const std::string& err_msg,
@@ -814,7 +815,7 @@ inline std::string format_error(const std::string& err_msg,
 {
     return detail::format_underline(err_msg, detail::get_region(v1), comment1,
                                              detail::get_region(v2), comment2,
-                                             hints);
+                                             std::move(hints));
 }
 
 }// toml

--- a/toml/value.hpp
+++ b/toml/value.hpp
@@ -801,17 +801,20 @@ inline bool operator>=(const toml::value& lhs, const toml::value& rhs)
 }
 
 inline std::string format_error(const std::string& err_msg,
-        const toml::value& v, const std::string& comment)
+        const toml::value& v, const std::string& comment,
+        std::vector<std::string> hints = {})
 {
-    return detail::format_underline(err_msg, detail::get_region(v), comment);
+    return detail::format_underline(err_msg, detail::get_region(v), comment, hints);
 }
 
 inline std::string format_error(const std::string& err_msg,
         const toml::value& v1, const std::string& comment1,
-        const toml::value& v2, const std::string& comment2)
+        const toml::value& v2, const std::string& comment2,
+        std::vector<std::string> hints = {})
 {
     return detail::format_underline(err_msg, detail::get_region(v1), comment1,
-                                             detail::get_region(v2), comment2);
+                                             detail::get_region(v2), comment2,
+                                             hints);
 }
 
 }// toml


### PR DESCRIPTION
It might be useful to have hints while writing an error message.