### PR TITLE
fix: open file as binary-mode #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ In the case of file open error, it will throw `std::runtime_error`.
 
 You can also pass a `stream` to the  `toml::parse` function after checking the status.
 
+Note that on __Windows OS__, stream that is opened as text-mode automatically converts
+CRLF ("\r\n") into LF ("\n") and this leads inconsistency between file size and
+the contents that would be read. This causes weird error. To use a file stream
+with `toml::parse`, don't forget to pass binary mode flag when you open the
+stream.
+
 ```cpp
-std::ifstream ifs("sample.toml");
+std::ifstream ifs("sample.toml", std::ios_base::binary);
 assert(ifs.good());
 const auto data = toml::parse(ifs /*, "filename" (optional)*/);
 ```

--- a/tests/test_parse_file.cpp
+++ b/tests/test_parse_file.cpp
@@ -220,8 +220,10 @@ BOOST_AUTO_TEST_CASE(test_file_with_BOM)
             "[table]\n"
             "key = \"value\"\n"
             );
-        std::ofstream ofs("tmp.toml");
-        ofs << table;
+        {
+            std::ofstream ofs("tmp.toml");
+            ofs << table;
+        }
         const auto data = toml::parse("tmp.toml");
 
         BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
@@ -247,8 +249,10 @@ BOOST_AUTO_TEST_CASE(test_file_with_BOM)
             "[table]\r\n"
             "key = \"value\"\r\n"
             );
-        std::ofstream ofs("tmp.toml");
-        ofs << table;
+        {
+            std::ofstream ofs("tmp.toml");
+            ofs << table;
+        }
         const auto data = toml::parse("tmp.toml");
 
         BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");

--- a/tests/test_parse_file.cpp
+++ b/tests/test_parse_file.cpp
@@ -216,12 +216,40 @@ BOOST_AUTO_TEST_CASE(test_file_with_BOM)
     {
         const std::string table(
             "\xEF\xBB\xBF" // BOM
+            "key = \"value\"\n"
+            "[table]\n"
+            "key = \"value\"\n"
+            );
+        std::ofstream ofs("tmp.toml");
+        ofs << table;
+        const auto data = toml::parse("tmp.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "\xEF\xBB\xBF" // BOM
             "key = \"value\"\r\n"
             "[table]\r\n"
             "key = \"value\"\r\n"
             );
         std::istringstream iss(table);
         const auto data = toml::parse(iss, "test_file_with_BOM_CRLF.toml");
+
+        BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
+        BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");
+    }
+    {
+        const std::string table(
+            "\xEF\xBB\xBF" // BOM
+            "key = \"value\"\r\n"
+            "[table]\r\n"
+            "key = \"value\"\r\n"
+            );
+        std::ofstream ofs("tmp.toml");
+        ofs << table;
+        const auto data = toml::parse("tmp.toml");
 
         BOOST_CHECK_EQUAL(toml::get <std::string>(data.at("key")), "value");
         BOOST_CHECK_EQUAL(toml::find<std::string>(data.at("table"), "key"), "value");

--- a/tests/test_parse_file.cpp
+++ b/tests/test_parse_file.cpp
@@ -250,8 +250,11 @@ BOOST_AUTO_TEST_CASE(test_file_with_BOM)
             "key = \"value\"\r\n"
             );
         {
-            std::ofstream ofs("tmp.toml");
-            ofs << table;
+            // with text-mode, "\n" is converted to "\r\n" and the resulting
+            // value will be "\r\r\n". To avoid the additional "\r", use binary
+            // mode.
+            std::ofstream ofs("tmp.toml", std::ios_base::binary);
+            ofs.write(table.data(), table.size());
         }
         const auto data = toml::parse("tmp.toml");
 

--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -1517,7 +1517,7 @@ inline table parse(std::istream& is, std::string fname = "unknown file")
 
 inline table parse(const std::string& fname)
 {
-    std::ifstream ifs(fname.c_str());
+    std::ifstream ifs(fname.c_str(), std::ios_base::binary);
     if(!ifs.good())
     {
         throw std::runtime_error("toml::parse: file open error -> " + fname);


### PR DESCRIPTION
to avoid inconsistency between file size (obtained by `tellg`) and the
size of the actual contents that would be read later

Also, test cases that uses file are added.