### PR TITLE
Error message for getting values corresponds to dotted keys

### DIFF
--- a/tests/test_parse_key.cpp
+++ b/tests/test_parse_key.cpp
@@ -13,23 +13,23 @@ using namespace detail;
 
 BOOST_AUTO_TEST_CASE(test_bare_key)
 {
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "barekey",  std::vector<key>(1, "barekey"));
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "bare-key", std::vector<key>(1, "bare-key"));
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "bare_key", std::vector<key>(1, "bare_key"));
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "1234",     std::vector<key>(1, "1234"));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "barekey",  std::vector<key>(1, "barekey"));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "bare-key", std::vector<key>(1, "bare-key"));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "bare_key", std::vector<key>(1, "bare_key"));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "1234",     std::vector<key>(1, "1234"));
 }
 
 BOOST_AUTO_TEST_CASE(test_quoted_key)
 {
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "\"127.0.0.1\"",          std::vector<key>(1, "127.0.0.1"         ));
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "\"character encoding\"", std::vector<key>(1, "character encoding"));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "\"127.0.0.1\"",          std::vector<key>(1, "127.0.0.1"         ));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "\"character encoding\"", std::vector<key>(1, "character encoding"));
 #if defined(_MSC_VER) || defined(__INTEL_COMPILER)
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "\"\xCA\x8E\xC7\x9D\xCA\x9E\"", std::vector<key>(1, "\xCA\x8E\xC7\x9D\xCA\x9E"));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "\"\xCA\x8E\xC7\x9D\xCA\x9E\"", std::vector<key>(1, "\xCA\x8E\xC7\x9D\xCA\x9E"));
 #else
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "\"ʎǝʞ\"",                std::vector<key>(1, "ʎǝʞ"               ));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "\"ʎǝʞ\"",                std::vector<key>(1, "ʎǝʞ"               ));
 #endif
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "'key2'",                 std::vector<key>(1, "key2"              ));
-    TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "'quoted \"value\"'",     std::vector<key>(1, "quoted \"value\""  ));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "'key2'",                 std::vector<key>(1, "key2"              ));
+    TOML11_TEST_PARSE_EQUAL(parse_key, "'quoted \"value\"'",     std::vector<key>(1, "quoted \"value\""  ));
 }
 
 BOOST_AUTO_TEST_CASE(test_dotted_key)
@@ -38,13 +38,13 @@ BOOST_AUTO_TEST_CASE(test_dotted_key)
         std::vector<key> keys(2);
         keys[0] = "physical";
         keys[1] = "color";
-        TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "physical.color", keys);
+        TOML11_TEST_PARSE_EQUAL(parse_key, "physical.color", keys);
     }
     {
         std::vector<key> keys(2);
         keys[0] = "physical";
         keys[1] = "shape";
-        TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "physical.shape", keys);
+        TOML11_TEST_PARSE_EQUAL(parse_key, "physical.shape", keys);
     }
     {
         std::vector<key> keys(4);
@@ -52,12 +52,12 @@ BOOST_AUTO_TEST_CASE(test_dotted_key)
         keys[1] = "y";
         keys[2] = "z";
         keys[3] = "w";
-        TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "x.y.z.w", keys);
+        TOML11_TEST_PARSE_EQUAL(parse_key, "x.y.z.w", keys);
     }
     {
         std::vector<key> keys(2);
         keys[0] = "site";
         keys[1] = "google.com";
-        TOML11_TEST_PARSE_EQUAL_VALUE(parse_key, "site.\"google.com\"", keys);
+        TOML11_TEST_PARSE_EQUAL(parse_key, "site.\"google.com\"", keys);
     }
 }

--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -905,7 +905,7 @@ parse_array(location<Container>& loc)
 }
 
 template<typename Container>
-result<std::pair<std::vector<key>, value>, std::string>
+result<std::pair<std::pair<std::vector<key>, region<Container>>, value>, std::string>
 parse_key_value_pair(location<Container>& loc)
 {
     const auto first = loc.iter();
@@ -968,7 +968,7 @@ parse_key_value_pair(location<Container>& loc)
         loc.iter() = first;
         return err(msg);
     }
-    return ok(std::make_pair(std::move(key_reg.unwrap().first),
+    return ok(std::make_pair(std::move(key_reg.unwrap()),
                              std::move(val.unwrap())));
 }
 
@@ -1193,8 +1193,9 @@ parse_inline_table(location<Container>& loc)
         {
             return err(kv_r.unwrap_err());
         }
-        const std::vector<key>& keys = kv_r.unwrap().first;
-        const value&            val  = kv_r.unwrap().second;
+        const std::vector<key>&  keys    = kv_r.unwrap().first.first;
+//      const region<Container>& key_reg = kv_r.unwrap().first.second;
+        const value&             val     = kv_r.unwrap().second;
 
         const auto inserted =
             insert_nested_key(retval, val, keys.begin(), keys.end());
@@ -1374,8 +1375,9 @@ result<table, std::string> parse_ml_table(location<Container>& loc)
 
         if(const auto kv = parse_key_value_pair(loc))
         {
-            const std::vector<key>& keys = kv.unwrap().first;
-            const value&            val  = kv.unwrap().second;
+            const std::vector<key>& keys     = kv.unwrap().first.first;
+//          const region<Container>& key_reg = kv_r.unwrap().first.second;
+            const value&            val      = kv.unwrap().second;
             const auto inserted =
                 insert_nested_key(tab, val, keys.begin(), keys.end());
             if(!inserted)

--- a/toml/value.hpp
+++ b/toml/value.hpp
@@ -21,8 +21,6 @@ namespace detail
 {
 // to show error messages. not recommended for users.
 region_base const& get_region(const value&);
-// ditto.
-void assign_keeping_region(value&, value);
 }// detail
 
 template<typename T>
@@ -562,9 +560,6 @@ class value
     // for error messages
     friend region_base const& detail::get_region(const value&);
 
-    // to see why it's here, see detail::insert_nested_key.
-    friend void detail::assign_keeping_region(value&, value);
-
     template<value_t T>
     struct switch_cast;
 
@@ -599,35 +594,7 @@ inline region_base const& get_region(const value& v)
 {
     return *(v.region_info_);
 }
-// If we keep region information after assigning another toml::* types, the
-// error message become different from the actual value contained.
-// To avoid this kind of confusing phenomena, the default assigners clear the
-// old region_info_. But this functionality is actually needed deep inside of
-// parser, so if you want to see the usecase, see toml::detail::insert_nested_key
-// defined in toml/parser.hpp.
-inline void assign_keeping_region(value& v, value other)
-{
-    v.cleanup(); // this keeps region info
-    // keep region_info_ intact
-    v.type_ = other.type();
-    switch(v.type())
-    {
-        case value_t::Boolean       : ::toml::value::assigner(v.boolean_        , other.boolean_        ); break;
-        case value_t::Integer       : ::toml::value::assigner(v.integer_        , other.integer_        ); break;
-        case value_t::Float         : ::toml::value::assigner(v.floating_       , other.floating_       ); break;
-        case value_t::String        : ::toml::value::assigner(v.string_         , other.string_         ); break;
-        case value_t::OffsetDatetime: ::toml::value::assigner(v.offset_datetime_, other.offset_datetime_); break;
-        case value_t::LocalDatetime : ::toml::value::assigner(v.local_datetime_ , other.local_datetime_ ); break;
-        case value_t::LocalDate     : ::toml::value::assigner(v.local_date_     , other.local_date_     ); break;
-        case value_t::LocalTime     : ::toml::value::assigner(v.local_time_     , other.local_time_     ); break;
-        case value_t::Array         : ::toml::value::assigner(v.array_          , other.array_          ); break;
-        case value_t::Table         : ::toml::value::assigner(v.table_          , other.table_          ); break;
-        default: break;
-    }
-    return;
-}
 }// detail
-
 
 template<> struct value::switch_cast<value_t::Boolean>
 {


### PR DESCRIPTION
Error messages related to the dotted keys looks weird. like:
```
 1 | a.b.c = 42
   |         ~~ in this table
```
The underlined token is not a table. This should be like the following.
```
 1 | a.b.c = 42
   | ~~~ in this table
```
This PR improves this by using key-region information when constructing a table.
```
  what():  [error] key "d" not found
 --> test.toml
 1 | a.b.c = 42
   | ~~~~~ in this table
```