### PR TITLE
feat: mark to_toml as deprecated

### DIFF
--- a/toml/to_toml.hpp
+++ b/toml/to_toml.hpp
@@ -8,32 +8,38 @@ namespace toml
 {
 
 template<typename T>
+TOML11_MARK_AS_DEPRECATED
 inline value to_toml(T&& x)
 {
     return value(std::forward<T>(x));
 }
 
 template<typename T>
+TOML11_MARK_AS_DEPRECATED
 inline value to_toml(T&& x, string_t kind)
 {
     return value(std::forward<T>(x), kind);
 }
 
+TOML11_MARK_AS_DEPRECATED
 inline value to_toml(local_date d, local_time t)
 {
     return value(local_datetime(d, t));
 }
+TOML11_MARK_AS_DEPRECATED
 inline value to_toml(local_date d, local_time t, time_offset ofs)
 {
     return value(offset_datetime(d, t, ofs));
 }
 
 template<typename ... Ts>
+TOML11_MARK_AS_DEPRECATED
 inline value to_toml(Ts&& ... xs)
 {
     return value(toml::array{toml::value(std::forward<Ts>(xs)) ... });
 }
 
+TOML11_MARK_AS_DEPRECATED
 inline value to_toml(std::initializer_list<std::pair<std::string, toml::value>> xs)
 {
     return value(toml::table(xs.begin(), xs.end()));

--- a/toml/utility.hpp
+++ b/toml/utility.hpp
@@ -7,6 +7,16 @@
 #include <memory>
 #include <sstream>
 
+#if __cplusplus >= 201402L
+#  define TOML11_MARK_AS_DEPRECATED [[deprecated]]
+#elif defined(__GNUC__)
+#  define TOML11_MARK_AS_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#  define TOML11_MARK_AS_DEPRECATED __declspec(deprecated)
+#else
+#  define TOML11_MARK_AS_DEPRECATED
+#endif
+
 namespace toml
 {
 


### PR DESCRIPTION
because the constructor of `toml::value()` supports all the stuff that
are supported by `to_toml`.

I will remove it in the next version, v2.2.0.