### PR TITLE
extended conversions

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_NAMES
     test_parse_unicode
     test_error_detection
     test_format_error
+    test_extended_conversions
 )
 
 CHECK_CXX_COMPILER_FLAG("-Wall" COMPILER_SUPPORTS_WALL)

--- a/tests/test_extended_conversions.cpp
+++ b/tests/test_extended_conversions.cpp
@@ -1,0 +1,82 @@
+#define BOOST_TEST_MODULE "test_extended_conversions"
+#ifdef UNITTEST_FRAMEWORK_LIBRARY_EXIST
+#include <boost/test/unit_test.hpp>
+#else
+#define BOOST_TEST_NO_LIB
+#include <boost/test/included/unit_test.hpp>
+#endif
+#include <toml.hpp>
+
+namespace extlib
+{
+struct foo
+{
+    int a;
+    std::string b;
+};
+struct bar
+{
+    int a;
+    std::string b;
+
+    void from_toml(const toml::value& v)
+    {
+        this->a = toml::find<int>(v, "a");
+        this->b = toml::find<std::string>(v, "b");
+        return ;
+    }
+
+    toml::table into_toml() const
+    {
+        return toml::table{{"a", this->a}, {"b", this->b}};
+    }
+};
+} // extlib
+
+namespace toml
+{
+template<>
+struct from<extlib::foo>
+{
+    static extlib::foo from_toml(const toml::value& v)
+    {
+        return extlib::foo{toml::find<int>(v, "a"), toml::find<std::string>(v, "b")};
+    }
+};
+
+template<>
+struct into<extlib::foo>
+{
+    static toml::table into_toml(const extlib::foo& f)
+    {
+        return toml::table{{"a", f.a}, {"b", f.b}};
+    }
+};
+} // toml
+
+
+BOOST_AUTO_TEST_CASE(test_conversion_by_member_methods)
+{
+    const toml::value v{{"a", 42}, {"b", "baz"}};
+
+    const auto foo = toml::get<extlib::foo>(v);
+    BOOST_TEST(foo.a == 42);
+    BOOST_TEST(foo.b == "baz");
+
+    const toml::value v2(foo);
+
+    BOOST_TEST(v == v2);
+}
+
+BOOST_AUTO_TEST_CASE(test_conversion_by_specialization)
+{
+    const toml::value v{{"a", 42}, {"b", "baz"}};
+
+    const auto bar = toml::get<extlib::bar>(v);
+    BOOST_TEST(bar.a == 42);
+    BOOST_TEST(bar.b == "baz");
+
+    const toml::value v2(bar);
+
+    BOOST_TEST(v == v2);
+}

--- a/tests/test_extended_conversions.cpp
+++ b/tests/test_extended_conversions.cpp
@@ -80,3 +80,37 @@ BOOST_AUTO_TEST_CASE(test_conversion_by_specialization)
 
     BOOST_TEST(v == v2);
 }
+
+BOOST_AUTO_TEST_CASE(test_recursive_conversion)
+{
+    const toml::value v{
+        toml::table{{"a", 42}, {"b", "baz"}},
+        toml::table{{"a", 43}, {"b", "qux"}},
+        toml::table{{"a", 44}, {"b", "quux"}},
+        toml::table{{"a", 45}, {"b", "foobar"}},
+    };
+
+    const auto foos = toml::get<std::vector<extlib::foo>>(v);
+    BOOST_TEST(foos.size() == 4ul);
+    BOOST_TEST(foos.at(0).a == 42);
+    BOOST_TEST(foos.at(1).a == 43);
+    BOOST_TEST(foos.at(2).a == 44);
+    BOOST_TEST(foos.at(3).a == 45);
+
+    BOOST_TEST(foos.at(0).b == "baz");
+    BOOST_TEST(foos.at(1).b == "qux");
+    BOOST_TEST(foos.at(2).b == "quux");
+    BOOST_TEST(foos.at(3).b == "foobar");
+
+    const auto bars = toml::get<std::vector<extlib::bar>>(v);
+    BOOST_TEST(bars.size() == 4ul);
+    BOOST_TEST(bars.at(0).a == 42);
+    BOOST_TEST(bars.at(1).a == 43);
+    BOOST_TEST(bars.at(2).a == 44);
+    BOOST_TEST(bars.at(3).a == 45);
+
+    BOOST_TEST(bars.at(0).b == "baz");
+    BOOST_TEST(bars.at(1).b == "qux");
+    BOOST_TEST(bars.at(2).b == "quux");
+    BOOST_TEST(bars.at(3).b == "foobar");
+}

--- a/tests/test_extended_conversions.cpp
+++ b/tests/test_extended_conversions.cpp
@@ -60,12 +60,12 @@ BOOST_AUTO_TEST_CASE(test_conversion_by_member_methods)
     const toml::value v{{"a", 42}, {"b", "baz"}};
 
     const auto foo = toml::get<extlib::foo>(v);
-    BOOST_TEST(foo.a == 42);
-    BOOST_TEST(foo.b == "baz");
+    BOOST_CHECK_EQUAL(foo.a, 42);
+    BOOST_CHECK_EQUAL(foo.b, "baz");
 
     const toml::value v2(foo);
 
-    BOOST_TEST(v == v2);
+    BOOST_CHECK_EQUAL(v, v2);
 }
 
 BOOST_AUTO_TEST_CASE(test_conversion_by_specialization)
@@ -73,12 +73,12 @@ BOOST_AUTO_TEST_CASE(test_conversion_by_specialization)
     const toml::value v{{"a", 42}, {"b", "baz"}};
 
     const auto bar = toml::get<extlib::bar>(v);
-    BOOST_TEST(bar.a == 42);
-    BOOST_TEST(bar.b == "baz");
+    BOOST_CHECK_EQUAL(bar.a, 42);
+    BOOST_CHECK_EQUAL(bar.b, "baz");
 
     const toml::value v2(bar);
 
-    BOOST_TEST(v == v2);
+    BOOST_CHECK_EQUAL(v, v2);
 }
 
 BOOST_AUTO_TEST_CASE(test_recursive_conversion)
@@ -91,26 +91,26 @@ BOOST_AUTO_TEST_CASE(test_recursive_conversion)
     };
 
     const auto foos = toml::get<std::vector<extlib::foo>>(v);
-    BOOST_TEST(foos.size() == 4ul);
-    BOOST_TEST(foos.at(0).a == 42);
-    BOOST_TEST(foos.at(1).a == 43);
-    BOOST_TEST(foos.at(2).a == 44);
-    BOOST_TEST(foos.at(3).a == 45);
+    BOOST_CHECK_EQUAL(foos.size()  , 4ul);
+    BOOST_CHECK_EQUAL(foos.at(0).a , 42);
+    BOOST_CHECK_EQUAL(foos.at(1).a , 43);
+    BOOST_CHECK_EQUAL(foos.at(2).a , 44);
+    BOOST_CHECK_EQUAL(foos.at(3).a , 45);
 
-    BOOST_TEST(foos.at(0).b == "baz");
-    BOOST_TEST(foos.at(1).b == "qux");
-    BOOST_TEST(foos.at(2).b == "quux");
-    BOOST_TEST(foos.at(3).b == "foobar");
+    BOOST_CHECK_EQUAL(foos.at(0).b , "baz");
+    BOOST_CHECK_EQUAL(foos.at(1).b , "qux");
+    BOOST_CHECK_EQUAL(foos.at(2).b , "quux");
+    BOOST_CHECK_EQUAL(foos.at(3).b , "foobar");
 
     const auto bars = toml::get<std::vector<extlib::bar>>(v);
-    BOOST_TEST(bars.size() == 4ul);
-    BOOST_TEST(bars.at(0).a == 42);
-    BOOST_TEST(bars.at(1).a == 43);
-    BOOST_TEST(bars.at(2).a == 44);
-    BOOST_TEST(bars.at(3).a == 45);
+    BOOST_CHECK_EQUAL(bars.size()  , 4ul);
+    BOOST_CHECK_EQUAL(bars.at(0).a , 42);
+    BOOST_CHECK_EQUAL(bars.at(1).a , 43);
+    BOOST_CHECK_EQUAL(bars.at(2).a , 44);
+    BOOST_CHECK_EQUAL(bars.at(3).a , 45);
 
-    BOOST_TEST(bars.at(0).b == "baz");
-    BOOST_TEST(bars.at(1).b == "qux");
-    BOOST_TEST(bars.at(2).b == "quux");
-    BOOST_TEST(bars.at(3).b == "foobar");
+    BOOST_CHECK_EQUAL(bars.at(0).b , "baz");
+    BOOST_CHECK_EQUAL(bars.at(1).b , "qux");
+    BOOST_CHECK_EQUAL(bars.at(2).b , "quux");
+    BOOST_CHECK_EQUAL(bars.at(3).b , "foobar");
 }

--- a/toml/from.hpp
+++ b/toml/from.hpp
@@ -1,0 +1,20 @@
+//     Copyright Toru Niina 2019.
+// Distributed under the MIT License.
+#ifndef TOML11_FROM_HPP
+#define TOML11_FROM_HPP
+#include "traits.hpp"
+
+namespace toml
+{
+
+template<typename T>
+struct from;
+// {
+//     static T from_toml(const toml::value& v)
+//     {
+//         // User-defined conversions ...
+//     }
+// };
+
+} // toml
+#endif // TOML11_FROM_HPP

--- a/toml/get.hpp
+++ b/toml/get.hpp
@@ -329,9 +329,7 @@ T get(const toml::value& v)
 }
 template<typename T, typename std::enable_if<detail::conjunction<
     detail::negation<detail::is_exact_toml_type<T>> // not a toml::value
-    >::value, std::nullptr_t>::type,
-    std::size_t = sizeof(::toml::from<T>) // and has from<T> specialization
-    >
+    >::value, std::nullptr_t>::type, std::size_t>   // and has from<T>
 T get(const toml::value& v)
 {
     return ::toml::from<T>::from_toml(v);

--- a/toml/get.hpp
+++ b/toml/get.hpp
@@ -174,6 +174,20 @@ template<typename T, typename std::enable_if<detail::conjunction<
     >::value, std::nullptr_t>::type = nullptr>
 T get(const toml::value& v);
 
+template<typename T, typename std::enable_if<detail::conjunction<
+    detail::negation<detail::is_exact_toml_type<T>>, // not a toml::value
+    detail::has_from_toml_method<T>, // but has from_toml(toml::value) memfn
+    std::is_default_constructible<T> // and default constructible
+    >::value, std::nullptr_t>::type = nullptr>
+T get(const toml::value& v);
+
+template<typename T, typename std::enable_if<detail::conjunction<
+    detail::negation<detail::is_exact_toml_type<T>> // not a toml::value
+    >::value, std::nullptr_t>::type = nullptr,
+    std::size_t = sizeof(::toml::from<T>) // and has from<T> specialization
+    >
+T get(const toml::value& v);
+
 // ============================================================================
 // array-like types; most likely STL container, like std::vector, etc.
 
@@ -306,7 +320,7 @@ template<typename T, typename std::enable_if<detail::conjunction<
     detail::negation<detail::is_exact_toml_type<T>>, // not a toml::value
     detail::has_from_toml_method<T>, // but has from_toml(toml::value) memfn
     std::is_default_constructible<T> // and default constructible
-    >::value, std::nullptr_t>::type = nullptr>
+    >::value, std::nullptr_t>::type>
 T get(const toml::value& v)
 {
     T ud;
@@ -315,7 +329,7 @@ T get(const toml::value& v)
 }
 template<typename T, typename std::enable_if<detail::conjunction<
     detail::negation<detail::is_exact_toml_type<T>> // not a toml::value
-    >::value, std::nullptr_t>::type = nullptr,
+    >::value, std::nullptr_t>::type,
     std::size_t = sizeof(::toml::from<T>) // and has from<T> specialization
     >
 T get(const toml::value& v)

--- a/toml/into.hpp
+++ b/toml/into.hpp
@@ -1,0 +1,20 @@
+//     Copyright Toru Niina 2019.
+// Distributed under the MIT License.
+#ifndef TOML11_INTO_HPP
+#define TOML11_INTO_HPP
+#include "traits.hpp"
+
+namespace toml
+{
+
+template<typename T>
+struct into;
+// {
+//     static toml::value into_toml(const T& user_defined_type)
+//     {
+//         // User-defined conversions ...
+//     }
+// };
+
+} // toml
+#endif // TOML11_INTO_HPP

--- a/toml/traits.hpp
+++ b/toml/traits.hpp
@@ -9,6 +9,9 @@
 
 namespace toml
 {
+
+class value; // forward decl
+
 namespace detail
 {
 
@@ -45,6 +48,22 @@ struct has_resize_method_impl
     template<typename T> static std::false_type check(...);
 };
 
+struct has_from_toml_method_impl
+{
+    template<typename T>
+    static std::true_type  check(
+        decltype(std::declval<T>().from_toml(std::declval<::toml::value>()))*);
+    template<typename T>
+    static std::false_type check(...);
+};
+struct has_into_toml_method_impl
+{
+    template<typename T>
+    static std::true_type  check(decltype(std::declval<T>().into_toml())*);
+    template<typename T>
+    static std::false_type check(...);
+};
+
 /// Intel C++ compiler can not use decltype in parent class declaration, here
 /// is a hack to work around it. https://stackoverflow.com/a/23953090/4692076
 #ifdef __INTEL_COMPILER
@@ -61,6 +80,14 @@ template<typename T>
 struct has_mapped_type : decltype(has_mapped_type_impl::check<T>(nullptr)){};
 template<typename T>
 struct has_resize_method : decltype(has_resize_method_impl::check<T>(nullptr)){};
+
+
+template<typename T>
+struct has_from_toml_method
+: decltype(has_from_toml_method_impl::check<T>(nullptr)){};
+template<typename T>
+struct has_into_toml_method
+: decltype(has_into_toml_method_impl::check<T>(nullptr)){};
 
 #ifdef __INTEL_COMPILER
 #undef decltype(...)

--- a/toml/value.hpp
+++ b/toml/value.hpp
@@ -3,6 +3,7 @@
 #ifndef TOML11_VALUE
 #define TOML11_VALUE
 #include "traits.hpp"
+#include "into.hpp"
 #include "utility.hpp"
 #include "exception.hpp"
 #include "storage.hpp"
@@ -532,6 +533,46 @@ class value
         assigner(this->table_, std::move(tab));
         return *this;
     }
+
+    // user-defined =========================================================
+
+    // convert using into_toml() method -------------------------------------
+
+    template<typename T, typename std::enable_if<detail::conjunction<
+        detail::negation<detail::is_exact_toml_type<T>>, // not a toml::value
+        detail::has_into_toml_method<T> // but has `into_toml` method
+        >::value, std::nullptr_t>::type = nullptr>
+    value(const T& ud): value(ud.into_toml()) {}
+
+    template<typename T, typename std::enable_if<detail::conjunction<
+        detail::negation<detail::is_exact_toml_type<T>>, // not a toml::value
+        detail::has_into_toml_method<T> // but has `into_toml` method
+        >::value, std::nullptr_t>::type = nullptr>
+    value& operator=(const T& ud)
+    {
+        *this = ud.into_toml();
+        return *this;
+    }
+
+    // convert using into<T> struct -----------------------------------------
+
+    template<typename T, typename std::enable_if<
+        detail::negation<detail::is_exact_toml_type<T>>::value,
+        std::nullptr_t>::type = nullptr,
+        std::size_t S = sizeof(::toml::into<T>)>
+    value(const T& ud): value(::toml::into<T>::into_toml(ud)) {}
+
+    template<typename T, typename std::enable_if<
+        detail::negation<detail::is_exact_toml_type<T>>::value,
+        std::nullptr_t>::type = nullptr,
+        std::size_t S = sizeof(::toml::into<T>)>
+    value& operator=(const T& ud)
+    {
+        *this = ::toml::into<T>::into_toml(ud);
+        return *this;
+    }
+
+    // type checking and casting ============================================
 
     template<typename T>
     bool is() const noexcept {return value_traits<T>::type_index == this->type_;}


### PR DESCRIPTION
support conversions between `toml::value` and `class/struct`s defined outside of toml11.