### PR TITLE
fix `get_or` and add `find_or`

### DIFF
--- a/tests/test_get_related_func.cpp
+++ b/tests/test_get_related_func.cpp
@@ -55,11 +55,66 @@ BOOST_AUTO_TEST_CASE(test_get_or)
         BOOST_CHECK_EQUAL(42, toml::get_or<int>(v, "num", 0));
         BOOST_CHECK_EQUAL(0,  toml::get_or<int>(v, "foo", 0));
     }
+
+
+    // requires conversion int -> uint
     {
         toml::value v1(42);
         toml::value v2(3.14);
-        BOOST_CHECK_EQUAL(42, toml::get_or<int>(v1, 0));
-        BOOST_CHECK_EQUAL(0,  toml::get_or<int>(v2, 0));
+        BOOST_CHECK_EQUAL(42u, toml::get_or(v1, 0u));
+        BOOST_CHECK_EQUAL(0u,  toml::get_or(v2, 0u));
+    }
+
+    // exact toml type
+    {
+        toml::value v1(42);
+        toml::value v2(3.14);
+        BOOST_CHECK_EQUAL(42, toml::get_or(v1, toml::integer(0)));
+        BOOST_CHECK_EQUAL(0,  toml::get_or(v2, toml::integer(0)));
+
+        toml::value v3("foobar");
+        toml::string s("bazqux");
+
+        BOOST_CHECK_EQUAL("foobar", toml::get_or(v3, s));
+        BOOST_CHECK_EQUAL("bazqux", toml::get_or(v1, s));
+
+    }
+
+    // std::string
+    {
+        toml::value v1("foobar");
+        toml::value v2(42);
+
+        std::string       s1("bazqux");
+        const std::string s2("bazqux");
+
+        BOOST_CHECK_EQUAL("foobar", toml::get_or(v1, s1));
+        BOOST_CHECK_EQUAL("bazqux", toml::get_or(v2, s1));
+
+        std::string& v1r = toml::get_or(v1, s1);
+        std::string& s1r = toml::get_or(v2, s1);
+
+        BOOST_CHECK_EQUAL("foobar", v1r);
+        BOOST_CHECK_EQUAL("bazqux", s1r);
+
+        BOOST_CHECK_EQUAL("foobar", toml::get_or(v1, s2));
+        BOOST_CHECK_EQUAL("bazqux", toml::get_or(v2, s2));
+
+        BOOST_CHECK_EQUAL("foobar", toml::get_or(v1, std::move(s1)));
+        BOOST_CHECK_EQUAL("bazqux", toml::get_or(v2, std::move(s1)));
+    }
+
+    // string literal
+    {
+        toml::value v1("foobar");
+        toml::value v2(42);
+
+        BOOST_CHECK_EQUAL("foobar", toml::get_or(v1, "bazqux"));
+        BOOST_CHECK_EQUAL("bazqux", toml::get_or(v2, "bazqux"));
+
+        const char* lit = "bazqux";
+        BOOST_CHECK_EQUAL("foobar", toml::get_or(v1, lit));
+        BOOST_CHECK_EQUAL("bazqux", toml::get_or(v2, lit));
     }
 }
 

--- a/toml/get.hpp
+++ b/toml/get.hpp
@@ -545,40 +545,6 @@ T get_or(const toml::value& v, T&& opt)
         return opt;
     }
 }
-template<typename T, typename std::enable_if<detail::conjunction<
-    detail::negation<detail::is_exact_toml_type<T>>,
-    detail::negation<std::is_same<T, std::string>>,
-    detail::negation<detail::is_string_literal<typename std::remove_reference<T>::type>>
-    >::value, std::nullptr_t>::type = nullptr>
-T get_or(toml::value& v, T&& opt)
-{
-    try
-    {
-        return get<typename std::remove_cv<
-            typename std::remove_reference<T>::type>::type>(v);
-    }
-    catch(...)
-    {
-        return opt;
-    }
-}
-template<typename T, typename std::enable_if<detail::conjunction<
-    detail::negation<detail::is_exact_toml_type<T>>,
-    detail::negation<std::is_same<T, std::string>>,
-    detail::negation<detail::is_string_literal<typename std::remove_reference<T>::type>>
-    >::value, std::nullptr_t>::type = nullptr>
-T get_or(toml::value&& v, T&& opt)
-{
-    try
-    {
-        return get<typename std::remove_cv<
-            typename std::remove_reference<T>::type>::type>(v);
-    }
-    catch(...)
-    {
-        return opt;
-    }
-}
 
 template<typename T>
 auto get_or(const toml::table& tab, const toml::key& ky, T&& opt)

--- a/toml/traits.hpp
+++ b/toml/traits.hpp
@@ -169,6 +169,21 @@ using return_type_of_t = typename std::result_of<F(Args...)>::type;
 
 #endif
 
+// ---------------------------------------------------------------------------
+// is_string_literal
+//
+// to use this, pass `typename remove_reference<T>::type` to T.
+
+template<typename T>
+struct is_string_literal:
+disjunction<
+    std::is_same<const char*, T>,
+    conjunction<
+        std::is_array<T>,
+        std::is_same<const char, typename std::remove_extent<T>::type>
+        >
+    >{};
+
 }// detail
 }//toml
 #endif // TOML_TRAITS

--- a/toml/utility.hpp
+++ b/toml/utility.hpp
@@ -8,11 +8,11 @@
 #include <sstream>
 
 #if __cplusplus >= 201402L
-#  define TOML11_MARK_AS_DEPRECATED [[deprecated]]
+#  define TOML11_MARK_AS_DEPRECATED(msg) [[deprecated(msg)]]
 #elif defined(__GNUC__)
-#  define TOML11_MARK_AS_DEPRECATED __attribute__((deprecated))
+#  define TOML11_MARK_AS_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif defined(_MSC_VER)
-#  define TOML11_MARK_AS_DEPRECATED __declspec(deprecated)
+#  define TOML11_MARK_AS_DEPRECATED(msg) __declspec(deprecated(msg))
 #else
 #  define TOML11_MARK_AS_DEPRECATED
 #endif


### PR DESCRIPTION
- improve overload resolution of `get_or(value, fallback)`
- add `toml::find_or(table, key, fallback)`
  - `toml::get_or(table, key, fallback)` is now deprecated