### PR TITLE
`toml::format` and top-level table

### DIFF
--- a/toml/serializer.hpp
+++ b/toml/serializer.hpp
@@ -483,17 +483,19 @@ struct serializer
 
 inline std::string
 format(const value& v, std::size_t w = 80,
-       int fprec = std::numeric_limits<toml::floating>::max_digits10)
+       int fprec = std::numeric_limits<toml::floating>::max_digits10,
+       bool force_inline = false)
 {
     // if value is a table, it is considered to be a root object.
     // the root object can't be an inline table. so pass false. otherwise, true.
-    return visit(serializer(w, fprec, !v.is_table()), v);
+    return visit(serializer(w, fprec, (!v.is_table()) || force_inline), v);
 }
 inline std::string
 format(const table& t, std::size_t w = 80,
-       int fprec = std::numeric_limits<toml::floating>::max_digits10)
+       int fprec = std::numeric_limits<toml::floating>::max_digits10,
+       bool force_inline = false)
 {
-    return serializer(w, fprec, false)(t);
+    return serializer(w, fprec, force_inline)(t);
 }
 
 template<typename charT, typename traits>

--- a/toml/serializer.hpp
+++ b/toml/serializer.hpp
@@ -485,13 +485,15 @@ inline std::string
 format(const value& v, std::size_t w = 80,
        int fprec = std::numeric_limits<toml::floating>::max_digits10)
 {
-    return visit(serializer(w, fprec, true), v);
+    // if value is a table, it is considered to be a root object.
+    // the root object can't be an inline table. so pass false. otherwise, true.
+    return visit(serializer(w, fprec, !v.is_table()), v);
 }
 inline std::string
 format(const table& t, std::size_t w = 80,
        int fprec = std::numeric_limits<toml::floating>::max_digits10)
 {
-    return serializer(w, fprec, true)(t);
+    return serializer(w, fprec, false)(t);
 }
 
 template<typename charT, typename traits>


### PR DESCRIPTION
`toml::format()` formats a value, so `toml::table` might be encoded as an inline table.
Using this results an incorrect toml file.

```cpp
std::cout << "a = " << toml::format(toml::table{{"a", 42}, {"b", "c"}});
// a = {a=42,b="c"}
std::cout << toml::format(toml::table{{"a", 42}, {"b", "c"}});
// {a=42,b="c"}
```

This PR introduces an extra argument to `toml::format` to control this behavior.

```cpp
std::cout << toml::format(toml::table{{"a", 42}, {"b", "c"}});
// a = 42
// b = "c"
std::cout << toml::format(toml::table{{"a", 42}, {"b", "c"}},
                          /*width*/ 80, /*prec*/ 6, /*force_inline*/ true);
// {a=42, b="c"}
```
