### PR TITLE
Speedup parsing large files

### DIFF
--- a/toml/literal.hpp
+++ b/toml/literal.hpp
@@ -39,7 +39,7 @@ inline ::toml::value operator""_toml(const char* str, std::size_t len)
     // literal is a TOML file (i.e. multiline table).
     if(auto data = ::toml::detail::parse_toml_file(loc))
     {
-        loc.iter() = loc.begin(); // rollback to the top of the literal
+        loc.reset(loc.begin()); // rollback to the top of the literal
         return ::toml::value(std::move(data.unwrap()),
                 ::toml::detail::region<std::vector<char>>(std::move(loc)));
     }

--- a/toml/region.hpp
+++ b/toml/region.hpp
@@ -62,9 +62,13 @@ struct region_base
 template<typename Container>
 struct location final : public region_base
 {
-    static_assert(std::is_same<char, typename Container::value_type>::value,"");
     using const_iterator = typename Container::const_iterator;
     using source_ptr     = std::shared_ptr<const Container>;
+
+    static_assert(std::is_same<char, typename Container::value_type>::value,"");
+    static_assert(std::is_same<std::random_access_iterator_tag,
+        typename std::iterator_traits<const_iterator>::iterator_category>::value,
+        "container should be randomly accessible");
 
     location(std::string name, Container cont)
       : source_(std::make_shared<Container>(std::move(cont))),
@@ -139,9 +143,13 @@ struct location final : public region_base
 template<typename Container>
 struct region final : public region_base
 {
-    static_assert(std::is_same<char, typename Container::value_type>::value,"");
     using const_iterator = typename Container::const_iterator;
     using source_ptr     = std::shared_ptr<const Container>;
+
+    static_assert(std::is_same<char, typename Container::value_type>::value,"");
+    static_assert(std::is_same<std::random_access_iterator_tag,
+        typename std::iterator_traits<const_iterator>::iterator_category>::value,
+        "container should be randomly accessible");
 
     // delete default constructor. source_ never be null.
     region() = delete;


### PR DESCRIPTION
For parsing large files, like a file having tens of thousands of lines, it takes some minutes. It is intolerably slow (for me).

By profiling the parser, I found the hotspot and fixed the problem. This improves the runtime efficiency.