### PR TITLE
Improve error message from toml literal

### DIFF
--- a/toml/literal.hpp
+++ b/toml/literal.hpp
@@ -73,6 +73,9 @@ inline ::toml::value operator""_toml(const char* str, std::size_t len)
     if(auto data = ::toml::detail::parse_toml_file(loc))
     {
         loc.reset(loc.begin()); // rollback to the top of the literal
+        // skip needless characters for error message
+        skip_line::invoke(loc); // skip the first several needless lines
+        skip_ws::invoke(loc);   // skip the first several needless whitespaces
         return ::toml::value(std::move(data.unwrap()),
                 ::toml::detail::region<std::vector<char>>(std::move(loc)));
     }

--- a/toml/region.hpp
+++ b/toml/region.hpp
@@ -343,7 +343,8 @@ inline std::string format_underline(const std::string& message,
         {
             // invalid
             // ~~~~~~~
-            retval << make_string(reg->size(), '~');
+            const auto underline_len = std::min(reg->size(), reg->line().size());
+            retval << make_string(underline_len, '~');
         }
 
         retval << ' ';


### PR DESCRIPTION
- skip empty lines at the beginning of toml literal
  - if toml literal is used with C++11 raw string literals, it may start with empty lines like the following.
    ```cpp
    // there is a newline after `u8R"(` and
    // it becomes an empty line at the beginning of literal.
    const auto v = u8R"(
        [table]
        key = "value"
    )"_toml;
    ```
  - skip this empty line to show a meaningful part of a literal in the error message.
- avoid too long underline
  - since `toml::detail::region::size()` returns a length of the whole region, a region that corresponds to a literal returns the length of whole literal. The region makes underline too long.
  - use the shortest one between a length of a region or a length of a line shown there.