### PR TITLE
Preserve comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ int main()
 - [Conversion between toml value and arbitrary types](#conversion-between-toml-value-and-arbitrary-types)
 - [Invalid UTF-8 Codepoints](#invalid-utf-8-codepoints)
 - [Formatting user-defined error messages](#formatting-user-defined-error-messages)
+- [Getting comments related to a value](#getting-comments)
 - [Serializing TOML data](#serializing-toml-data)
 - [Underlying types](#underlying-types)
 - [Running Tests](#running-tests)
@@ -830,6 +831,53 @@ you will get an error message like this.
  4 | max = 42
    |       ~~ maximum number here
 ```
+
+## Getting comments
+
+Since toml11 keeps a file data until all the values are destructed, you can
+also extract a comment related to a value by calling `toml::value::comment()`.
+
+If there is a comment just after a value (within the same line), you can get
+the specific comment by `toml::value::comment_inline()`.
+
+If there are comments just before a value (without any newline between them),
+you can get the comments by `toml::value::comment_before()`.
+
+`toml::value::comment()` returns the results of both functions after
+concatenating them.
+
+```toml
+a = 42 # comment for a.
+
+# comment for b.
+# this is also a comment for b.
+b = "foo"
+
+c = [ # comment for c.
+    3.14, # this is not a comment for c, but for 3.14.
+] # this is also a comment for c.
+```
+
+```cpp
+// "# comment for a."
+const std::string com1 = toml::find(data, "a").comment();
+
+// "# comment for b."
+const std::string com2 = toml::find(data, "b").comment();
+
+// "# comment for c.\n# this is also a comment for c."
+const std::string com3 = toml::find(data, "c").comment();
+
+// "# this is not a comment for c, but for 3.14."
+const std::string com3 = toml::find<toml::array>(data, "c").front().comment();
+```
+
+Note that once a data in a value is modified, the related file region
+information would be deleted. Thus after modifying a data, you cannot find any
+comments.
+
+Also note that currently it does not support any way to set a comment to a value.
+And currently, serializer does not take comments into account.
 
 ## Serializing TOML data
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_NAMES
     test_parse_key
     test_parse_table_key
     test_literals
+    test_comments
     test_get
     test_get_related_func
     test_from_toml

--- a/tests/test_comments.cpp
+++ b/tests/test_comments.cpp
@@ -1,0 +1,123 @@
+#define BOOST_TEST_MODULE "test_comments"
+#ifdef UNITTEST_FRAMEWORK_LIBRARY_EXIST
+#include <boost/test/unit_test.hpp>
+#else
+#define BOOST_TEST_NO_LIB
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <toml.hpp>
+
+BOOST_AUTO_TEST_CASE(test_comment_before)
+{
+    using namespace toml::literals::toml_literals;
+    {
+        const toml::value v = u8R"(
+            # comment for a.
+            a = 42
+            # comment for b.
+            b = "baz"
+        )"_toml;
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_before(), u8"# comment for a.");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_before(), u8"# comment for b.");
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_inline(), "");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_inline(), "");
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment(), u8"# comment for a.");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment(), u8"# comment for b.");
+    }
+
+    {
+        const toml::value v = u8R"(
+            # comment for a.
+            # another comment for a.
+            a = 42
+            # comment for b.
+            # also comment for b.
+            b = "baz"
+        )"_toml;
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_before(), u8R"(# comment for a.
+# another comment for a.)");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_before(), u8R"(# comment for b.
+# also comment for b.)");
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_inline(), u8"");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_inline(), u8"");
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment(), u8R"(# comment for a.
+# another comment for a.)");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment(), u8R"(# comment for b.
+# also comment for b.)");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_comment_inline)
+{
+    using namespace toml::literals::toml_literals;
+    {
+        const toml::value v = u8R"(
+            a = 42    # comment for a.
+            b = "baz" # comment for b.
+        )"_toml;
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_before(), "");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_before(), "");
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_inline(), u8"# comment for a.");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_inline(), u8"# comment for b.");
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment(), u8"# comment for a.");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment(), u8"# comment for b.");
+    }
+    {
+        const toml::value v = u8R"(
+            a = [    # comment for a.
+                42,
+            ] # this also.
+            b = [ # comment for b.
+                "bar",
+            ]
+            c = [
+                3.14,
+            ] # comment for c.
+        )"_toml;
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_before(), "");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_before(), "");
+        BOOST_CHECK_EQUAL(toml::find(v, "c").comment_before(), "");
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_inline(), u8R"(# comment for a.
+# this also.)");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_inline(), u8"# comment for b.");
+        BOOST_CHECK_EQUAL(toml::find(v, "c").comment_inline(), u8"# comment for c.");
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment(),  u8R"(# comment for a.
+# this also.)");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment(), u8"# comment for b.");
+        BOOST_CHECK_EQUAL(toml::find(v, "c").comment(), u8"# comment for c.");
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(test_comment_both)
+{
+    using namespace toml::literals::toml_literals;
+    {
+        const toml::value v = u8R"(
+            # comment for a.
+            a = 42 # inline comment for a.
+            # comment for b.
+            b = "baz" # inline comment for b.
+        )"_toml;
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_before(), "# comment for a.");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_before(), "# comment for b.");
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment_inline(), "# inline comment for a.");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment_inline(), "# inline comment for b.");
+
+        BOOST_CHECK_EQUAL(toml::find(v, "a").comment(), u8R"(# comment for a.
+# inline comment for a.)");
+        BOOST_CHECK_EQUAL(toml::find(v, "b").comment(), u8R"(# comment for b.
+# inline comment for b.)");
+    }
+}

--- a/tests/test_comments.cpp
+++ b/tests/test_comments.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(test_comment_inline)
                 "bar",
             ]
             c = [
-                3.14,
+                3.14, # this is not a comment for c, but 3.14.
             ] # comment for c.
         )"_toml;
 
@@ -95,8 +95,10 @@ BOOST_AUTO_TEST_CASE(test_comment_inline)
 # this also.)");
         BOOST_CHECK_EQUAL(toml::find(v, "b").comment(), u8"# comment for b.");
         BOOST_CHECK_EQUAL(toml::find(v, "c").comment(), u8"# comment for c.");
-    }
 
+        const auto& c0 = toml::find<toml::array>(v, "c").at(0);
+        BOOST_CHECK_EQUAL(c0.comment(), u8"# this is not a comment for c, but 3.14.");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_comment_both)

--- a/toml/value.hpp
+++ b/toml/value.hpp
@@ -607,6 +607,19 @@ class value
     template<value_t T>
     typename detail::toml_default_type<T>::type&&      cast() &&;
 
+    std::string comment() const
+    {
+        return this->region_info_->comment();
+    }
+    std::string comment_before() const
+    {
+        return this->region_info_->comment_before();
+    }
+    std::string comment_inline() const
+    {
+        return this->region_info_->comment_inline();
+    }
+
   private:
 
     void cleanup() noexcept


### PR DESCRIPTION
This provides a way to extract comments that are related to a `toml::value`.

It does not add any `std::string` member variables but member functions to `toml::value`. It does not have any impact on memory usage.

Note that this PR does not provide a way to preserve comments in the serialized file or to change comments related to a `toml::value`.