### PR TITLE
Update documentation for toml::from and toml::into

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,7 +1091,7 @@ namespace toml
 template<>
 struct from<ext::foo>
 {
-    ext::foo from_toml(const value& v)
+    static ext::foo from_toml(const value& v)
     {
         ext::foo f;
         f.a = find<int        >(v, "a");
@@ -1131,7 +1131,7 @@ template<>
 struct from<ext::foo>
 {
     template<typename C, template<typename ...> class M, template<typename ...> class A>
-    ext::foo from_toml(const basic_value<C, M, A>& v)
+    static ext::foo from_toml(const basic_value<C, M, A>& v)
     {
         ext::foo f;
         f.a = find<int        >(v, "a");
@@ -1187,7 +1187,7 @@ namespace toml
 template<>
 struct into<ext::foo>
 {
-    toml::table into_toml(const ext::foo& f)
+    static toml::table into_toml(const ext::foo& f)
     {
         return toml::table{{"a", f.a}, {"b", f.b}, {"c", f.c}};
     }


### PR DESCRIPTION
The example code for converting between toml values and arbitrary types does not compile because `toml::from<T>::from_toml` and `toml::into<T>::into_toml` are not static. I'm assuming they're meant to be static because the unit test [here](https://github.com/ToruNiina/toml11/blob/master/tests/test_extended_conversions.cpp#L38-L57) has them written that way.

This partially addresses #83, however I am not sure whether or not it is intended that **both**  `toml::from` and `toml::into` need be specialized before you can use `toml::find` with arbitrary types.