### PR TITLE
Suppress warning on Intel C++ Compiler

### DIFF
--- a/toml/traits.hpp
+++ b/toml/traits.hpp
@@ -105,7 +105,7 @@ struct has_into_toml_method
 : decltype(has_into_toml_method_impl::check<T>(nullptr)){};
 
 #ifdef __INTEL_COMPILER
-#undef decltype(...)
+#undef decltype
 #endif
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Intel C++ Compiler 18.0.5 outputs the following warning:

```
toml11/toml/traits.hpp(108): warning #14: extra text after expected end of preprocessing directive
  #undef decltype(...)
                 ^
```

This PR fixes the above.