### PR TITLE
when parsing a local_time, parse up to 9 digits worth (nanoseconds) o…

### DIFF
--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -733,7 +733,13 @@ parse_local_time(location<Container>& loc)
                 case 0:  break;
                 default: break;
             }
-            if(sf.size() >= 6)
+            if(sf.size() >= 9)
+            {
+                time.millisecond = from_string<std::uint16_t>(sf.substr(0, 3), 0u);
+                time.microsecond = from_string<std::uint16_t>(sf.substr(3, 3), 0u);
+                time.nanosecond  = from_string<std::uint16_t>(sf.substr(6, 3), 0u);
+            }
+            else if(sf.size() >= 6)
             {
                 time.millisecond = from_string<std::uint16_t>(sf.substr(0, 3), 0u);
                 time.microsecond = from_string<std::uint16_t>(sf.substr(3, 3), 0u);


### PR DESCRIPTION
…f fractional seconds

I'm not able to build the tests--for some reason it's not able to find the boost libs, even though they are there in /usr/lib. But using my own tests I have confirmed that this change works as expected.