### PR TITLE
Fix MSVC warning C4866

### DIFF
--- a/toml/serializer.hpp
+++ b/toml/serializer.hpp
@@ -697,7 +697,8 @@ format(const basic_value<C, M, V>& v, std::size_t w = 80u,
             oss << v.comments();
             oss << '\n'; // to split the file comment from the first element
         }
-        oss << visit(serializer<value_type>(w, fprec, no_comment, false), v);
+        const auto serialized = visit(serializer<value_type>(w, fprec, no_comment, false), v);
+        oss << serialized;
         return oss.str();
     }
     return visit(serializer<value_type>(w, fprec, force_inline), v);
@@ -753,7 +754,8 @@ operator<<(std::basic_ostream<charT, traits>& os, const basic_value<C, M, V>& v)
         os << '\n'; // to split the file comment from the first element
     }
     // the root object can't be an inline table. so pass `false`.
-    os << visit(serializer<value_type>(w, fprec, false, no_comment), v);
+    const auto serialized = visit(serializer<value_type>(w, fprec, no_comment, false), v);
+    os << serialized;
 
     // if v is a non-table value, and has only one comment, then
     // put a comment just after a value. in the following way.


### PR DESCRIPTION
This fixes the warning "compiler may not enforce left-to-right evaluation order for call to" that is caused by Visual Studio if this is compiled with a target of C++17.

I have a [branch at my fork](https://github.com/ToruNiina/toml11/compare/master...SeverinLeonhardt:fix_msvc_c4866_with_tests) with test cases to demonstrate the warning. As [documented by Microsoft](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4866?view=vs-2019) this warning only applies when compiling with `/std:c++17` which I just hacked in for demonstration purposes. If you prefer to have such test cases please let me know how to handle the requirement to compile for C++17.