### PR TITLE
Fix include path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ int main()
 Just include the file after adding it to the include path.
 
 ```cpp
-#include <toml11/toml.hpp> // that's all! now you can use it.
+#include <toml.hpp> // that's all! now you can use it.
 #include <iostream>
 
 int main()


### PR DESCRIPTION
In #72, the include path in README has been changed from `<toml11/toml.hpp>` to `<toml.hpp>`, but there is still an example of including `<toml11/toml.hpp>`.

This PR fix it.
