### PR TITLE
fix: serializer has wrong constructor params order when format root object

### DIFF
--- a/toml/serializer.hpp
+++ b/toml/serializer.hpp
@@ -833,7 +833,7 @@ format(const basic_value<C, M, V>& v, std::size_t w = 80u,
             oss << v.comments();
             oss << '\n'; // to split the file comment from the first element
         }
-        const auto serialized = visit(serializer<value_type>(w, fprec, no_comment, false), v);
+        const auto serialized = visit(serializer<value_type>(w, fprec, false, no_comment), v);
         oss << serialized;
         return oss.str();
     }


### PR DESCRIPTION
Due to serializer constructor:

```c++
    serializer(const std::size_t w              = 80u,
               const int         float_prec     = std::numeric_limits<toml::floating>::max_digits10,
               const bool        can_be_inlined = false,
               const bool        no_comment     = false,
               std::vector<toml::key> ks        = {},
               const bool     value_has_comment = false)
        : can_be_inlined_(can_be_inlined), no_comment_(no_comment),
          value_has_comment_(value_has_comment && !no_comment),
          float_prec_(float_prec), width_(w), keys_(std::move(ks))
    {}
```

`can_be_inlined` should be the third param and `no_comment` should be the fourth param, but in `format` function, it has wrong order:

```c++
        const auto serialized = visit(serializer<value_type>(w, fprec, no_comment, false), v);
```
