### PR TITLE
fix a compile error in a code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ int main()
     std::vector<int> nums = toml::find<std::vector<int>>(data, "nums");
 
     // access with STL-like manner
-    if(not data.contains("foo"))
+    if(!data.contains("foo"))
     {
         data["foo"] = "bar";
     }


### PR DESCRIPTION
`not` keyword is not defined in C++ and the code example  causes a compile error.
This PR fixes the issue above.