### PR TITLE
Resolve g++ warning: free-nonheap-object

### DIFF
--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -2134,7 +2134,7 @@ result<Value, std::string> parse_toml_file(location& loc)
 
     table_type data;
     // root object is also a table, but without [tablename]
-    if(auto tab = parse_ml_table<value_type>(loc))
+    if(const auto tab = parse_ml_table<value_type>(loc))
     {
         data = std::move(tab.unwrap());
     }


### PR DESCRIPTION
As described in issue #173, this warning is raised on various platforms and in various build types. For example, g++ 11 in release mode will cause this warning to be raised. This change fixes this warning.