### PR TITLE
Support opting out of the default `[error]` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1630,6 +1630,15 @@ Note: It colorize `[error]` in red. That means that it detects `[error]` prefix
 at the front of the error message. If there is no `[error]` prefix,
 `format_error` adds it to the error message.
 
+## Opting out of the default `[error]` prefix
+
+toml11 prints error messages with the `[error]` prefix by default.
+Defining `TOML11_NO_ERROR_PREFIX` will let toml11 omit the prefix regardless of colorized or not in case you would use a custom prefix, such as `Error:`.
+
+```cpp
+#define TOML11_NO_ERROR_PREFIX
+```
+
 ## Serializing TOML data
 
 toml11 enables you to serialize data into toml format.

--- a/toml/source_location.hpp
+++ b/toml/source_location.hpp
@@ -137,12 +137,18 @@ inline std::string format_underline(const std::string& message,
     // if it is "[error]", it removes that part from the message shown.
     if(message.size() > 7 && message.substr(0, 7) == "[error]")
     {
-        retval << color::bold << color::red << "[error]" << color::reset
+        retval
+#ifndef TOML11_NO_ERROR_PREFIX
+               << color::bold << color::red << "[error]" << color::reset
+#endif
                << color::bold << message.substr(7) << color::reset << '\n';
     }
     else
     {
-        retval << color::bold << color::red << "[error] " << color::reset
+        retval
+#ifndef TOML11_NO_ERROR_PREFIX
+               << color::bold << color::red << "[error] " << color::reset
+#endif
                << color::bold << message << color::reset << '\n';
     }
 


### PR DESCRIPTION
toml11 prints error messages with the `[error]` prefix by default.
Defining `TOML11_NO_ERROR_PREFIX` will let toml11 omit the prefix regardless of colorized or not in case you would use a custom prefix, such as `Error:`.

```cpp
#define TOML11_NO_ERROR_PREFIX
```

---

Without `TOML11_NO_ERROR_PREFIX`:

```console
[error] value should be positive
 --> example.toml
 3 | num = -42
   |       ~~~ positive number required
```

With `TOML11_NO_ERROR_PREFIX`:

```console
value should be positive
 --> example.toml
 3 | num = -42
   |       ~~~ positive number required
```

We are now able to customize the prefix like:

```cpp
fmt::print("Error: {}", e.what());
```

This prints out:

```console
Error: value should be positive
 --> example.toml
 3 | num = -42
   |       ~~~ positive number required
```
