### PR TITLE
fix: don't force a copy of std::string fname when moving is an option

### DIFF
--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -2317,7 +2317,7 @@ template<typename                     Comment = TOML11_DEFAULT_COMMENT_STRATEGY,
          template<typename ...> class Table   = std::unordered_map,
          template<typename ...> class Array   = std::vector>
 basic_value<Comment, Table, Array>
-parse(std::istream& is, const std::string& fname = "unknown file")
+parse(std::istream& is, std::string fname = "unknown file")
 {
     using value_type = basic_value<Comment, Table, Array>;
 
@@ -2372,14 +2372,14 @@ parse(std::istream& is, const std::string& fname = "unknown file")
 template<typename                     Comment = TOML11_DEFAULT_COMMENT_STRATEGY,
          template<typename ...> class Table   = std::unordered_map,
          template<typename ...> class Array   = std::vector>
-basic_value<Comment, Table, Array> parse(const std::string& fname)
+basic_value<Comment, Table, Array> parse(std::string fname)
 {
     std::ifstream ifs(fname.c_str(), std::ios_base::binary);
     if(!ifs.good())
     {
         throw std::runtime_error("toml::parse: file open error -> " + fname);
     }
-    return parse<Comment, Table, Array>(ifs, fname);
+    return parse<Comment, Table, Array>(ifs, std::move(fname));
 }
 
 #ifdef TOML11_HAS_STD_FILESYSTEM


### PR DESCRIPTION
Taking this parameter by const reference forces us to copy it (because
we know we're going to store it). Taking it by r-value reference would
suggest that we _might_ take ownership over it and would also force the
user to make a copy if they wish to retain the original value.

Taking this parameter by value however clearly gives us ownership of its
content without forcing a copy if it's implicit conversion from
`const char*` or explicitly handed over to us by the user via std::move.

Also note that without this the `std::move` call already present in `parse`
is effectively a NOP. (I.e. it calls the *const* r-value ref constructor of
`std::string`, which doesn't exist, so falls back to const l-value ref.).