### PR TITLE
Fix address-sanitizer error when parsing literal strings having invalid UTF-8 characters

### DIFF
--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -664,7 +664,8 @@ parse_literal_string(location& loc)
     const auto first = loc.iter();
     if(const auto token = lex_literal_string::invoke(loc))
     {
-        location inner_loc(loc.name(), token.unwrap().str());
+        auto inner_loc = loc;
+        inner_loc.reset(first);
 
         const auto open = lex_apostrophe::invoke(inner_loc);
         if(!open)

--- a/toml/parser.hpp
+++ b/toml/parser.hpp
@@ -588,7 +588,8 @@ parse_ml_literal_string(location& loc)
     const auto first = loc.iter();
     if(const auto token = lex_ml_literal_string::invoke(loc))
     {
-        location inner_loc(loc.name(), token.unwrap().str());
+        auto inner_loc = loc;
+        inner_loc.reset(first);
 
         const auto open = lex_ml_literal_string_open::invoke(inner_loc);
         if(!open)


### PR DESCRIPTION
The inner iterator in `parse_ml_literal_string()` and `parse_literal_string()` was being reset to an iterator into a different region of memory.  Fix that by using the same iterator initialization as is used in the `parse*_basic_string()`.

Fixes #199.

Demonstration of the fix: 
[poc2.zip](https://github.com/ToruNiina/toml11/files/10419111/poc2.zip)
```
$ unzip poc2.zip
$ g++ -fsanitize=address -g -o issue199 issue199.cpp && ./issue199 poc.toml ; echo $?
[error] parse_ml_basic_string: invalid utf8 sequence found
 --> poc.toml
   |
 1 | str3 = 'C:\highway\to\�he\danger\zone'
   |                       ^--- here
1
```