### PR TITLE
Update checkout action to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
             - {compiler: 'g++-7', standard: '20'}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install
@@ -51,7 +51,7 @@ jobs:
             - {compiler: '9',   standard: '20'}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install
@@ -80,7 +80,7 @@ jobs:
         unreleased: ['ON', 'OFF']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install
@@ -110,7 +110,7 @@ jobs:
         unreleased: ['ON', 'OFF']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install
@@ -139,7 +139,7 @@ jobs:
         unreleased: ['ON', 'OFF']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install
@@ -165,7 +165,7 @@ jobs:
         unreleased: ['ON', 'OFF']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install


### PR DESCRIPTION
Updates  *checkout* v2 action – which uses [deprecated NodeJS 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) – to v3.