### PR TITLE
Require CMake 3.5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 enable_testing()
 
 project(toml11 VERSION 3.7.1)


### PR DESCRIPTION
According to [CMake 3.27 release notes](https://cmake.org/cmake/help/latest/release/3.27.html#deprecated-and-removed-features):

> Compatibility with versions of CMake older than 3.5 is now deprecated and will be removed from a future version. 