### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/toml11
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/toml11

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+# Copy fuzzer executable to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/toml11/.clusterfuzzlite/parse_fuzzer.cpp \
+  -o $OUT/parse_fuzzer \
+  -I$SRC/toml11/

--- a/.clusterfuzzlite/parse_fuzzer.cpp
+++ b/.clusterfuzzlite/parse_fuzzer.cpp
@@ -1,0 +1,16 @@
+
+#include <toml.hpp>
+
+#include <sstream>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string s(reinterpret_cast<const char *>(data), size);
+  std::istringstream iss(s);
+  try {
+    const auto ref = toml::parse(iss);
+  } catch (...) {
+  }
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 240
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `toml::parse` and currently set the timeout of CFLite to 240 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss)) you can do:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/toml11
cd toml11
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD parse_fuzzer -- -max_total_time=10
```