### PR TITLE
Fix issues with CMake package configuration when used with vcpkg #110

### DIFF
--- a/cmake/toml11Config.cmake.in
+++ b/cmake/toml11Config.cmake.in
@@ -1,2 +1,2 @@
 @PACKAGE_INIT@
-include("@PACKAGE_toml11_install_cmake_dir@/toml11Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/toml11Targets.cmake")


### PR DESCRIPTION
I was trying to use this with vcpkg and encountered issues described in #110 . I've simply applied the changes described in this comment: https://github.com/ToruNiina/toml11/issues/110#issuecomment-917493436

Tested this locally with an overlay-port and was able to build using toml11 as a vcpkg port.'

I won't pretend to know exactly why this was an issue. I'm new to using vcpkg and CMake in general, just know that the fix described in the comment has worked and I did the legwork of applying and testing locally with vcpkg.