### PR TITLE
Fix not checking for \r\n when parsing line comments

### DIFF
--- a/include/toml11/parser.hpp
+++ b/include/toml11/parser.hpp
@@ -1855,7 +1855,14 @@ skip_multiline_spacer(location& loc, context<TC>& ctx, const bool newline_found 
         {
             spacer.newline_found = true;
             auto comment = comm.as_string();
-            if( ! comment.empty() && comment.back() == '\n') {comment.pop_back();}
+            if( ! comment.empty() && comment.back() == '\n')
+            {
+                comment.pop_back();
+                if (!comment.empty() && comment.back() == '\r')
+                {
+                    comment.pop_back();
+                }
+            }
 
             spacer.comments.push_back(std::move(comment));
             spacer.indent_type = indent_char::none;


### PR DESCRIPTION
Fix for issue #252 
Parser now checks for a carriage return when removing the newline at the end of a line comment, and if present removes it as well.