### PR TITLE
Support template into_toml members (Issue #255)

### DIFF
--- a/include/toml11/traits.hpp
+++ b/include/toml11/traits.hpp
@@ -83,6 +83,14 @@ struct has_into_toml_method_impl
     static std::false_type check(...);
 };
 
+struct has_template_into_toml_method_impl
+{
+    template<typename T, typename TypeConfig>
+    static std::true_type  check(decltype(std::declval<T>().template into_toml<TypeConfig>())*);
+    template<typename T, typename TypeConfig>
+    static std::false_type check(...);
+};
+
 struct has_specialized_from_impl
 {
     template<typename T>
@@ -125,6 +133,9 @@ struct has_from_toml_method: decltype(has_from_toml_method_impl::check<T, TC>(nu
 
 template<typename T>
 struct has_into_toml_method: decltype(has_into_toml_method_impl::check<T>(nullptr)){};
+
+template<typename T, typename TypeConfig>
+struct has_template_into_toml_method: decltype(has_template_into_toml_method_impl::check<T, TypeConfig>(nullptr)){};
 
 template<typename T>
 struct has_specialized_from: decltype(has_specialized_from_impl::check<T>(nullptr)){};

--- a/include/toml11/value.hpp
+++ b/include/toml11/value.hpp
@@ -1085,6 +1085,29 @@ class basic_value
         *this = ud.into_toml();
         return *this;
     }
+
+    template<typename T, cxx::enable_if_t<cxx::conjunction<
+            detail::has_template_into_toml_method<T, TypeConfig>,
+            cxx::negation<detail::has_specialized_into<T>>
+        >::value, std::nullptr_t> = nullptr>
+    basic_value(const T& ud): basic_value(ud.template into_toml<TypeConfig>()) {}
+
+    template<typename T, cxx::enable_if_t<cxx::conjunction<
+            detail::has_template_into_toml_method<T, TypeConfig>,
+            cxx::negation<detail::has_specialized_into<T>>
+        >::value, std::nullptr_t> = nullptr>
+    basic_value(const T& ud, std::vector<std::string> com)
+        : basic_value(ud.template into_toml<TypeConfig>(), std::move(com))
+    {}
+    template<typename T, cxx::enable_if_t<cxx::conjunction<
+            detail::has_template_into_toml_method<T, TypeConfig>,
+            cxx::negation<detail::has_specialized_into<T>>
+        >::value, std::nullptr_t> = nullptr>
+    basic_value& operator=(const T& ud)
+    {
+        *this = ud.template into_toml<TypeConfig>();
+        return *this;
+    }
     // }}}
 
     // empty value with region info ======================================= {{{

--- a/tests/test_user_defined_conversion.cpp
+++ b/tests/test_user_defined_conversion.cpp
@@ -49,6 +49,25 @@ struct foobar
     int a;
     std::string b;
 };
+
+struct corge
+{
+    int a;
+    std::string b;
+
+    void from_toml(const toml::value& v)
+    {
+        this->a = toml::find<int>(v, "a");
+        this->b = toml::find<std::string>(v, "b");
+        return ;
+    }
+
+    template <typename TC>
+    toml::basic_value<TC> into_toml() const
+    {
+        return toml::basic_value<TC>(typename toml::basic_value<TC>::table_type{{"a", this->a}, {"b", this->b}});
+    }
+};
 } // extlib
 
 namespace toml
@@ -213,6 +232,19 @@ TEST_CASE("test_conversion_by_member_methods")
 
         const toml::value v2(foo);
         CHECK(v == v2);
+    }
+
+    
+    {
+        const toml::value v(toml::table{{"a", 42}, {"b", "baz"}});
+
+        const auto corge = toml::get<extlib::corge>(v);
+        CHECK_EQ(corge.a, 42);
+        CHECK_EQ(corge.b, "baz");
+
+        const toml::value v2(corge);
+
+        CHECK_EQ(v, v2);
     }
 
     {


### PR DESCRIPTION
Add a `has_template_into_toml_member` trait to support constructing or assigning to toml::basic_value with template `into_toml` method, as in the [doc](https://toruniina.github.io/toml11/docs/features/value/#defining-into_toml-member-function) and Issue #255.