### PR TITLE
feat: install cmake config module in arch-indep location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ check_cxx_compiler_flag("-Wundef"               TOML11_COMPILER_SUPPORTS_WUNDEF)
 check_cxx_compiler_flag("-Wshadow"              TOML11_COMPILER_SUPPORTS_WSHADOW)
 
 include(GNUInstallDirs)
-set(TOML11_INSTALL_CMAKE_DIR   ${CMAKE_INSTALL_LIBDIR}/cmake/toml11)
+set(TOML11_INSTALL_CMAKE_DIR   ${CMAKE_INSTALL_DATAROOTDIR}/cmake/toml11)
 set(TOML11_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 set(TOML11_CONFIG_DIR          ${CMAKE_CURRENT_BINARY_DIR}/cmake)
 set(TOML11_CONFIG              ${TOML11_CONFIG_DIR}/toml11Config.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,7 @@ if(TOML11_INSTALL)
     write_basic_package_version_file(${TOML11_CONFIG_VERSION}
         VERSION ${toml11_VERSION}
         COMPATIBILITY SameMajorVersion
+        ARCH_INDEPENDENT
         )
 
     configure_package_config_file(


### PR DESCRIPTION
toml11 is an header-only library, and the exported cmake target for it only points to the headers; because of this, it seems a good idea to install the cmake config module in an architecture-independent location for cmake, rather than under a library (architecture-dependent) location.

Doing so is easy:
- tweak `TOML11_INSTALL_CMAKE_DIR` to point to a cmake subdirectory of the shared dataroot location (typically `$prefix/share`)
- pass `ARCH_INDEPENDENT` argument to `write_basic_package_version_file()`: this is because the cmake config module generated by default contains the architecture bits check (32bit vs 64bit vs ...); since it does not matter in this case, make the config module arch-independent