### PR TITLE
fix: manually cast file size to std::streamsize

### DIFF
--- a/include/toml11/parser.hpp
+++ b/include/toml11/parser.hpp
@@ -3526,7 +3526,7 @@ try_parse(std::istream& is, std::string fname = "unknown file", spec s = spec::d
     // read whole file as a sequence of char
     assert(fsize >= 0);
     std::vector<detail::location::char_type> letters(static_cast<std::size_t>(fsize), '\0');
-    is.read(reinterpret_cast<char*>(letters.data()), fsize);
+    is.read(reinterpret_cast<char*>(letters.data()), static_cast<std::streamsize>(fsize));
 
     return detail::parse_impl<TC>(std::move(letters), std::move(fname), std::move(s));
 }


### PR DESCRIPTION
When reading a file to vector, manually cast the file size (represented as `std::streamoff` hidden as `auto`) to `std::streamsize`, which is the type for `std::istream::read()`; this avoids the warning/error

```
  error: conversion from ‘long long int’ to ‘std::streamsize’ {aka ‘int’} may change value [-Werror=conversion]
```

This means a truncation happens on 32bit architectures, however that seems a limitation of the standard library.