### PR TITLE
Support std::optional members for TOML11_DEFINE_CONVERSION_NON_INTRUSIVE

### DIFF
--- a/include/toml11/version.hpp
+++ b/include/toml11/version.hpp
@@ -77,6 +77,12 @@
 #  endif
 #endif
 
+#if TOML11_CPLUSPLUS_STANDARD_VERSION >= TOML11_CXX17_VALUE
+#  if __has_include(<optional>)
+#    define TOML11_HAS_OPTIONAL 1
+#  endif
+#endif
+
 #if defined(TOML11_COMPILE_SOURCES)
 #  define TOML11_INLINE
 #else


### PR DESCRIPTION
This PR enables support for `std::optional` members for `TOML11_DEFINE_CONVERSION_NON_INTRUSIVE`.  If a user-defined struct has a `std::optional` member and a TOML value doesn't have the key, the key-value will be `std::nullopt`. Similarly, if the struct's member holds `std::nullopt`, the conversion to TOML value will not include the key-value.

```cpp
struct my_toml
{
  int a;
  std::optional<int> b;
};

TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(my_toml, a, b)

const toml::value v = toml::parse_str("a = 42");
const auto foo = toml::get<my_toml>(v);

assert(foo.a == 42);
assert(!foo.b.has_value());
```