### PR TITLE
Make thread_local for color_mode optional

### DIFF
--- a/include/toml11/fwd/color_fwd.hpp
+++ b/include/toml11/fwd/color_fwd.hpp
@@ -9,6 +9,12 @@
 #define TOML11_ERROR_MESSAGE_COLORIZED false
 #endif
 
+#ifdef TOML11_USE_THREAD_LOCAL_COLORIZATION
+#define TOML11_THREAD_LOCAL_COLORIZATION thread_local
+#else
+#define TOML11_THREAD_LOCAL_COLORIZATION
+#endif
+
 namespace toml
 {
 namespace color
@@ -44,7 +50,7 @@ class color_mode
 
 inline color_mode& color_status() noexcept
 {
-    static thread_local color_mode status;
+    static TOML11_THREAD_LOCAL_COLORIZATION color_mode status;
     return status;
 }
 


### PR DESCRIPTION
closes: https://github.com/ToruNiina/toml11/issues/259

I used `TOML11_USE_THREAD_LOCAL_COLORIZATION` instead of `TOML11_THREAD_LOCAL_COLORIZATION` for the switch, as I think this is clearer.