### PR TITLE
Fix typos in documentation template syntax

### DIFF
--- a/docs/content.en/docs/features/value.md
+++ b/docs/content.en/docs/features/value.md
@@ -595,7 +595,7 @@ namespace toml
 template<>
 struct from<extlib::foo>
 {
-    template<typename <TC>
+    template<typename TC>
     static extlib::foo from_toml(const toml::basic_value<TC>& v)
     {
         return extlib::foo{

--- a/docs/content.ja/docs/features/value.md
+++ b/docs/content.ja/docs/features/value.md
@@ -622,7 +622,7 @@ namespace toml
 template<>
 struct from<extlib::foo>
 {
-    template<typename <TC>
+    template<typename TC>
     static extlib::foo from_toml(const toml::basic_value<TC>& v)
     {
         return extlib::foo{


### PR DESCRIPTION
Remove the extra < in template syntax