### PR TITLE
Fix use with CMake 3.21 and older

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@ option(TOML11_PRECOMPILE "precompile toml11 library" OFF)
 
 include(CMakeDependentOption)
 cmake_policy(PUSH)
+if(POLICY CMP0127)
 cmake_policy(SET CMP0127 OLD) # syntax of condition changed in 3.22
+endif()
 cmake_dependent_option(TOML11_INSTALL "install toml11 library" ON
     "${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}" OFF)
 cmake_dependent_option(TOML11_BUILD_EXAMPLES "build toml11 examples" OFF


### PR DESCRIPTION
The minimum required CMake version is 3.16 but CMP0127 was only introduced in 3.22. This results in errors with versions 3.16 - 3.21:

```
CMake Error at CMakeLists.txt:28 (cmake_policy):

  Policy "CMP0127" is not known to this version of CMake.
```

Fixed by only setting the policy when it's actually available.