### PR TITLE
Use is_void<T> instead of is_same<T, void>

### DIFF
--- a/include/toml11/result.hpp
+++ b/include/toml11/result.hpp
@@ -32,7 +32,7 @@ struct bad_result_access final : public ::toml::exception
 template<typename T>
 struct success
 {
-    static_assert( ! std::is_same<T, void>::value, "");
+    static_assert( ! std::is_void<T>::value, "");
 
     using value_type = T;
 
@@ -66,7 +66,7 @@ struct success
 template<typename T>
 struct success<std::reference_wrapper<T>>
 {
-    static_assert( ! std::is_same<T, void>::value, "");
+    static_assert( ! std::is_void<T>::value, "");
 
     using value_type = T;
 


### PR DESCRIPTION
The original code incorrectly accepts cv-qualified void types for success.