### PR TITLE
Remove whitespace in operator""

### DIFF
--- a/include/toml11/fwd/literal_fwd.hpp
+++ b/include/toml11/fwd/literal_fwd.hpp
@@ -19,7 +19,7 @@ inline namespace literals
 inline namespace toml_literals
 {
 
-::toml::value operator"" _toml(const char* str, std::size_t len);
+::toml::value operator""_toml(const char* str, std::size_t len);
 
 #if defined(TOML11_HAS_CHAR8_T)
 // value of u8"" literal has been changed from char to char8_t and char8_t is

--- a/include/toml11/impl/literal_impl.hpp
+++ b/include/toml11/impl/literal_impl.hpp
@@ -115,7 +115,7 @@ inline namespace toml_literals
 {
 
 TOML11_INLINE ::toml::value
-operator"" _toml(const char* str, std::size_t len)
+operator""_toml(const char* str, std::size_t len)
 {
     if(len == 0)
     {


### PR DESCRIPTION
Clang 20+ errors about this whitespace.

Fixes
include/toml11/impl/../fwd/literal_fwd.hpp:22:26: error: identifier '_toml' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
|    22 | ::toml::value operator"" _toml(const char* str, std::size_t len);
|       |               ~~~~~~~~~~~^~~~~
|       |               operator""_toml