### PR TITLE
add support for `toml::get<std::unordered_set>`

### DIFF
--- a/include/toml11/get.hpp
+++ b/include/toml11/get.hpp
@@ -405,7 +405,7 @@ template<typename T, typename TC>
 cxx::enable_if_t<toml::detail::is_unordered_set<T>::value, T>
 get(const basic_value<TC>& v)
 {
-    using value_type = T;
+    using value_type = typename T::value_type;
     const auto& a = v.as_array();
 
     std::unordered_set<T> container;

--- a/include/toml11/get.hpp
+++ b/include/toml11/get.hpp
@@ -399,6 +399,25 @@ get(const basic_value<TC>& v)
 }
 
 // ============================================================================
+// std::unordered_set
+
+template<typename T, typename TC>
+cxx::enable_if_t<toml::detail::is_unordered_set<T>::value, T>
+get(const basic_value<TC>& v)
+{
+    using value_type = T;
+    const auto& a = v.as_array();
+
+    std::unordered_set<T> container;
+    for (const auto& elem : a)
+    {
+        container.insert(get<value_type>(elem));
+    }
+    return container;
+}
+
+
+// ============================================================================
 // map-like types; most likely STL map, like std::map or std::unordered_map.
 
 // key is convertible from toml::value::key_type

--- a/include/toml11/get.hpp
+++ b/include/toml11/get.hpp
@@ -408,7 +408,7 @@ get(const basic_value<TC>& v)
     using value_type = typename T::value_type;
     const auto& a = v.as_array();
 
-    std::unordered_set<T> container;
+    T container;
     for (const auto& elem : a)
     {
         container.insert(get<value_type>(elem));

--- a/include/toml11/traits.hpp
+++ b/include/toml11/traits.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 #if defined(TOML11_HAS_STRING_VIEW)

--- a/include/toml11/traits.hpp
+++ b/include/toml11/traits.hpp
@@ -165,6 +165,12 @@ struct is_std_tuple_impl<std::tuple<Ts...>> : std::true_type{};
 template<typename T>
 using is_std_tuple = is_std_tuple_impl<cxx::remove_cvref_t<T>>;
 
+template<typename T> struct is_unordered_set_impl : std::false_type {};
+template<typename T, typename Hash, typename KeyEqual, typename Alloc>
+struct is_unordered_set_impl<std::unordered_set<T, Hash, KeyEqual, Alloc>> : std::true_type {};
+template<typename T>
+using is_unordered_set = is_unordered_set_impl<cxx::remove_cvref_t<T>>;
+
 #if defined(TOML11_HAS_OPTIONAL)
 template<typename T> struct is_std_optional_impl : std::false_type{};
 template<typename T>

--- a/include/toml11/traits.hpp
+++ b/include/toml11/traits.hpp
@@ -167,8 +167,8 @@ template<typename T>
 using is_std_tuple = is_std_tuple_impl<cxx::remove_cvref_t<T>>;
 
 template<typename T> struct is_unordered_set_impl : std::false_type {};
-template<typename T, typename Hash, typename KeyEqual, typename Alloc>
-struct is_unordered_set_impl<std::unordered_set<T, Hash, KeyEqual, Alloc>> : std::true_type {};
+template<typename T>
+struct is_unordered_set_impl<std::unordered_set<T>> : std::true_type {};
 template<typename T>
 using is_unordered_set = is_unordered_set_impl<cxx::remove_cvref_t<T>>;
 

--- a/tests/test_get.cpp
+++ b/tests/test_get.cpp
@@ -406,6 +406,44 @@ TEST_CASE("testing toml::get<array-of-arrays>")
     }
 }
 
+TEST_CASE("testing toml::get<unordered_set>")
+{
+    using value_type = toml::value;
+
+    {
+        const value_type v(toml::array{1, 2, 3, 4});
+        const std::unordered_set<int> uset = toml::get<std::unordered_set<int>>(v);
+
+        CHECK_EQ(uset.size(), 4u);
+        CHECK(uset.count(1) == 1);
+        CHECK(uset.count(2) == 1);
+        CHECK(uset.count(3) == 1);
+        CHECK(uset.count(4) == 1);
+    }
+
+    {
+        const value_type v(toml::array{"alpha", "beta", "delta"});
+        const std::unordered_set<std::string> uset = toml::get<std::unordered_set<std::string>>(v);
+
+        CHECK_EQ(uset.size(), 3u);
+        CHECK(uset.count("alpha") == 1);
+        CHECK(uset.count("beta") == 1);
+        CHECK(uset.count("delta") == 1);
+    }
+
+    {
+        value_type v(toml::array{42, 42, 54, 69});
+        const std::unordered_set<int> uset = toml::get<std::unordered_set<int>>(std::move(v));
+
+        // Set will only have one "42"
+        CHECK_EQ(uset.size(), 3u);
+        CHECK(uset.count(42) == 1);
+        CHECK(uset.count(54) == 1);
+        CHECK(uset.count(69) == 1);
+    }
+}
+
+
 TEST_CASE("testing toml::get<table-like>")
 {
     using value_type = toml::value;


### PR DESCRIPTION
Easier than calling `toml::get<std::vector<T>>` then having to convert it to `std::unordered_set`

As part of the PR I added a couple of basic tests. They are mostly for demonstrating that this works.