### PR TITLE
Use an inline namespace to distinguish emitted symbols by version numbers

### DIFF
--- a/include/toml11/compat.hpp
+++ b/include/toml11/compat.hpp
@@ -63,6 +63,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace cxx
 {
 
@@ -81,6 +83,7 @@ std::unique_ptr<T> make_unique(Ts&& ... args)
 #endif // TOML11_HAS_STD_MAKE_UNIQUE
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -94,6 +97,8 @@ std::unique_ptr<T> make_unique(Ts&& ... args)
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -112,6 +117,7 @@ std::reverse_iterator<Iterator> make_reverse_iterator(Iterator iter)
 #endif // TOML11_HAS_STD_MAKE_REVERSE_ITERATOR
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -125,6 +131,8 @@ std::reverse_iterator<Iterator> make_reverse_iterator(Iterator iter)
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -144,6 +152,7 @@ T clamp(const T& x, const T& low, const T& high) noexcept
 #endif // TOML11_HAS_STD_CLAMP
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -157,6 +166,8 @@ T clamp(const T& x, const T& low, const T& high) noexcept
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -183,6 +194,7 @@ U bit_cast(const T& x) noexcept
 #endif // TOML11_HAS_STD_BIT_CAST
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -197,6 +209,8 @@ U bit_cast(const T& x) noexcept
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -220,6 +234,7 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 #endif // TOML11_HAS_STD_REMOVE_CVREF
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -234,6 +249,8 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -265,6 +282,7 @@ struct negation : std::integral_constant<bool, !static_cast<bool>(T::value)>{};
 #endif // TOML11_HAS_STD_CONJUNCTION
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -279,6 +297,8 @@ struct negation : std::integral_constant<bool, !static_cast<bool>(T::value)>{};
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -324,6 +344,7 @@ using make_index_sequence = typename index_sequence_maker<N>::type;
 #endif // TOML11_HAS_STD_INTEGER_SEQUENCE
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -339,6 +360,8 @@ using make_index_sequence = typename index_sequence_maker<N>::type;
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace cxx
 {
 #if defined(TOML11_HAS_STD_ENABLE_IF_T)
@@ -353,6 +376,7 @@ using enable_if_t = typename std::enable_if<B, T>::type;
 #endif // TOML11_HAS_STD_ENABLE_IF_T
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -367,6 +391,8 @@ using enable_if_t = typename std::enable_if<B, T>::type;
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -384,6 +410,7 @@ using return_type_of_t = typename std::result_of<F(Args...)>::type;
 #endif // TOML11_HAS_STD_INVOKE_RESULT
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -399,6 +426,8 @@ using return_type_of_t = typename std::result_of<F(Args...)>::type;
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace cxx
 {
 #if defined(TOML11_HAS_STD_VOID_T)
@@ -413,6 +442,7 @@ using void_t = void;
 #endif // TOML11_HAS_STD_VOID_T
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ----------------------------------------------------------------------------
@@ -457,6 +487,8 @@ using void_t = void;
 #include <source_location>
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace cxx
 {
 using source_location = std::source_location;
@@ -477,10 +509,13 @@ inline std::string to_string(const source_location& loc)
 }
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #elif defined(TOML11_HAS_EXPERIMENTAL_SOURCE_LOCATION)
 #include <experimental/source_location>
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -502,9 +537,12 @@ inline std::string to_string(const source_location& loc)
 }
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #elif defined(TOML11_HAS_BUILTIN_FILE_LINE)
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -546,9 +584,12 @@ inline std::string to_string(const source_location& loc)
 }
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #else // no builtin
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -562,6 +603,7 @@ inline std::string to_string(const source_location&)
     return std::string("");
 }
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_HAS_STD_SOURCE_LOCATION
 
@@ -586,6 +628,8 @@ inline std::string to_string(const source_location&)
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace cxx
 {
 using std::optional;
@@ -601,11 +645,14 @@ operator<<(std::basic_ostream<charT, traitsT>& os, const std::nullopt_t&)
 }
 
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 #else // TOML11_HAS_STD_OPTIONAL
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace cxx
 {
@@ -804,6 +851,7 @@ class optional
     };
 };
 } // cxx
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_HAS_STD_OPTIONAL
 

--- a/include/toml11/context.hpp
+++ b/include/toml11/context.hpp
@@ -8,6 +8,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace detail
 {
 
@@ -50,10 +52,13 @@ class context
 };
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 #if defined(TOML11_COMPILE_SOURCES)
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 struct type_config;
 struct ordered_type_config;
@@ -62,6 +67,7 @@ namespace detail
 extern template class context<::toml::type_config>;
 extern template class context<::toml::ordered_type_config>;
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COMPILE_SOURCES
 

--- a/include/toml11/conversion.hpp
+++ b/include/toml11/conversion.hpp
@@ -181,7 +181,7 @@ void assign_member_variable_to_value(const T& obj, basic_value<TC>& v, const cha
 
 #define TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(NAME, ...)\
     namespace toml {                                                                     \
-    namespace TOML11_INLINE_VERSION_NAMESPACE {                                          \
+    inline namespace TOML11_INLINE_VERSION_NAMESPACE {                                          \
     template<>                                                                           \
     struct from<NAME>                                                                    \
     {                                                                                    \

--- a/include/toml11/conversion.hpp
+++ b/include/toml11/conversion.hpp
@@ -4,12 +4,15 @@
 #include "find.hpp"
 #include "from.hpp" // IWYU pragma: keep
 #include "into.hpp" // IWYU pragma: keep
+#include "version.hpp"
 
 #if defined(TOML11_HAS_OPTIONAL)
 
 #include <optional>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -57,11 +60,14 @@ void assign_member_variable_to_value(const T& obj, basic_value<TC>& v, const cha
 }
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 #else
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -79,6 +85,7 @@ void assign_member_variable_to_value(const T& obj, basic_value<TC>& v, const cha
 }
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 #endif // optional
@@ -174,6 +181,7 @@ void assign_member_variable_to_value(const T& obj, basic_value<TC>& v, const cha
 
 #define TOML11_DEFINE_CONVERSION_NON_INTRUSIVE(NAME, ...)\
     namespace toml {                                                                     \
+    namespace TOML11_INLINE_VERSION_NAMESPACE {                                          \
     template<>                                                                           \
     struct from<NAME>                                                                    \
     {                                                                                    \
@@ -196,6 +204,7 @@ void assign_member_variable_to_value(const T& obj, basic_value<TC>& v, const cha
             return v;                                                                    \
         }                                                                                \
     };                                                                                   \
+    } /* TOML11_INLINE_VERSION_NAMESPACE */                                              \
     } /* toml */
 
 #endif// TOML11_WITHOUT_DEFINE_NON_INTRUSIVE

--- a/include/toml11/exception.hpp
+++ b/include/toml11/exception.hpp
@@ -3,7 +3,11 @@
 
 #include <exception>
 
+#include "version.hpp"
+
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 struct exception : public std::exception
@@ -13,5 +17,6 @@ struct exception : public std::exception
     virtual const char* what() const noexcept override {return "";}
 };
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOMl11_EXCEPTION_HPP

--- a/include/toml11/find.hpp
+++ b/include/toml11/find.hpp
@@ -5,12 +5,15 @@
 
 #include "get.hpp"
 #include "value.hpp"
+#include "version.hpp"
 
 #if defined(TOML11_HAS_STRING_VIEW)
 #include <string_view>
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 // ----------------------------------------------------------------------------
@@ -584,5 +587,6 @@ find_or_default(const basic_value<TC>& v, K1&& k1, Ks&& ... keys) noexcept(std::
     }
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_FIND_HPP

--- a/include/toml11/from.hpp
+++ b/include/toml11/from.hpp
@@ -1,7 +1,10 @@
 #ifndef TOML11_FROM_HPP
 #define TOML11_FROM_HPP
+#include "version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 template<typename T>
@@ -13,5 +16,6 @@ struct from;
 //     }
 // };
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_FROM_HPP

--- a/include/toml11/fwd/color_fwd.hpp
+++ b/include/toml11/fwd/color_fwd.hpp
@@ -3,6 +3,8 @@
 
 #include <iosfwd>
 
+#include "../version.hpp"
+
 #ifdef TOML11_COLORIZE_ERROR_MESSAGE
 #define TOML11_ERROR_MESSAGE_COLORIZED true
 #else
@@ -16,6 +18,8 @@
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace color
 {
@@ -84,5 +88,6 @@ inline bool should_color()
 }
 
 } // color
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COLOR_FWD_HPP

--- a/include/toml11/fwd/comments_fwd.hpp
+++ b/include/toml11/fwd/comments_fwd.hpp
@@ -23,6 +23,8 @@
 // error whenever you access to the element.
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 class discard_comments; // forward decl
 
 class preserve_comments
@@ -447,5 +449,6 @@ inline void swap(const discard_comments&, const discard_comments&) noexcept {ret
 
 inline std::ostream& operator<<(std::ostream& os, const discard_comments&) {return os;}
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml11
 #endif // TOML11_COMMENTS_FWD_HPP

--- a/include/toml11/fwd/datetime_fwd.hpp
+++ b/include/toml11/fwd/datetime_fwd.hpp
@@ -9,7 +9,11 @@
 #include <cstdlib>
 #include <ctime>
 
+#include "../version.hpp"
+
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 enum class month_t : std::uint8_t
@@ -257,5 +261,6 @@ std::ostream& operator<<(std::ostream& os, const offset_datetime& dt);
 
 std::string to_string(const offset_datetime& dt);
 
-}//toml
+} // TOML11_INLINE_VERSION_NAMESPACE
+} // toml
 #endif // TOML11_DATETIME_FWD_HPP

--- a/include/toml11/fwd/error_info_fwd.hpp
+++ b/include/toml11/fwd/error_info_fwd.hpp
@@ -3,8 +3,11 @@
 
 #include "../source_location.hpp"
 #include "../utility.hpp"
+#include "../version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 // error info returned from parser.
@@ -93,5 +96,6 @@ std::string format_error(std::string title,
 
 std::ostream& operator<<(std::ostream& os, const error_info& e);
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_ERROR_INFO_FWD_HPP

--- a/include/toml11/fwd/format_fwd.hpp
+++ b/include/toml11/fwd/format_fwd.hpp
@@ -8,7 +8,11 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "../version.hpp"
+
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 // toml types with serialization info
@@ -246,5 +250,6 @@ struct value_with_format
 };
 } // detail
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_FORMAT_FWD_HPP

--- a/include/toml11/fwd/literal_fwd.hpp
+++ b/include/toml11/fwd/literal_fwd.hpp
@@ -7,6 +7,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 
 namespace detail
 {
@@ -29,5 +31,6 @@ inline namespace toml_literals
 
 } // toml_literals
 } // literals
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_LITERAL_FWD_HPP

--- a/include/toml11/fwd/location_fwd.hpp
+++ b/include/toml11/fwd/location_fwd.hpp
@@ -2,12 +2,15 @@
 #define TOML11_LOCATION_FWD_HPP
 
 #include "../result.hpp"
+#include "../version.hpp"
 
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -145,5 +148,6 @@ std::size_t count(const location& first, const location& last,
                   const location::char_type& c);
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_LOCATION_FWD_HPP

--- a/include/toml11/fwd/region_fwd.hpp
+++ b/include/toml11/fwd/region_fwd.hpp
@@ -2,6 +2,7 @@
 #define TOML11_REGION_FWD_HPP
 
 #include "../location.hpp"
+#include "../version.hpp"
 
 #include <string>
 #include <vector>
@@ -9,6 +10,8 @@
 #include <cassert>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -106,5 +109,6 @@ class region
 };
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_REGION_FWD_HPP

--- a/include/toml11/fwd/scanner_fwd.hpp
+++ b/include/toml11/fwd/scanner_fwd.hpp
@@ -2,6 +2,7 @@
 #define TOML11_SCANNER_FWD_HPP
 
 #include "../region.hpp"
+#include "../version.hpp"
 
 #include <memory>
 #include <string>
@@ -13,6 +14,8 @@
 #include <cctype>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -362,5 +365,6 @@ class maybe final: public scanner_base
 };
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_SCANNER_FWD_HPP

--- a/include/toml11/fwd/source_location_fwd.hpp
+++ b/include/toml11/fwd/source_location_fwd.hpp
@@ -2,12 +2,15 @@
 #define TOML11_SOURCE_LOCATION_FWD_HPP
 
 #include "../region.hpp"
+#include "../version.hpp"
 
 #include <sstream>
 #include <string>
 #include <vector>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 //
@@ -144,5 +147,6 @@ std::string format_location(
     return detail::format_location_rec(lnw, f, loc, msg, tail...);
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_SOURCE_LOCATION_FWD_HPP

--- a/include/toml11/fwd/syntax_fwd.hpp
+++ b/include/toml11/fwd/syntax_fwd.hpp
@@ -3,8 +3,11 @@
 
 #include "../scanner.hpp"
 #include "../spec.hpp"
+#include "../version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -411,5 +414,6 @@ literal const& null_value(const spec&);
 
 } // namespace syntax
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_SYNTAX_FWD_HPP

--- a/include/toml11/fwd/value_t_fwd.hpp
+++ b/include/toml11/fwd/value_t_fwd.hpp
@@ -3,6 +3,7 @@
 
 #include "../compat.hpp"
 #include "../format.hpp"
+#include "../version.hpp"
 
 #include <iosfwd>
 #include <string>
@@ -11,6 +12,8 @@
 #include <cstdint>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 // forward decl
@@ -113,5 +116,6 @@ template<typename T, typename V> struct is_exact_toml_type: is_exact_toml_type0<
 template<typename T, typename V> struct is_not_toml_type : cxx::negation<is_exact_toml_type<T, V>> {};
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_VALUE_T_FWD_HPP

--- a/include/toml11/get.hpp
+++ b/include/toml11/get.hpp
@@ -6,12 +6,15 @@
 #include "from.hpp"
 #include "types.hpp"
 #include "value.hpp"
+#include "version.hpp"
 
 #if defined(TOML11_HAS_STRING_VIEW)
 #include <string_view>
 #endif // string_view
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 // ============================================================================
@@ -647,5 +650,6 @@ get_or(const basic_value<TC>& v, T&& opt)
     }
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_GET_HPP

--- a/include/toml11/impl/color_impl.hpp
+++ b/include/toml11/impl/color_impl.hpp
@@ -8,6 +8,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace color
 {
 // put ANSI escape sequence to ostream
@@ -72,5 +74,6 @@ TOML11_INLINE std::ostream& white  (std::ostream& os)
 
 } // ansi
 } // color
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COLOR_IMPL_HPP

--- a/include/toml11/impl/comments_impl.hpp
+++ b/include/toml11/impl/comments_impl.hpp
@@ -2,8 +2,11 @@
 #define TOML11_COMMENTS_IMPL_HPP
 
 #include "../fwd/comments_fwd.hpp" // IWYU pragma: keep
+#include "../version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 TOML11_INLINE bool operator==(const preserve_comments& lhs, const preserve_comments& rhs) {return lhs.comments == rhs.comments;}
@@ -42,5 +45,6 @@ TOML11_INLINE std::ostream& operator<<(std::ostream& os, const preserve_comments
     return os;
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml11
 #endif // TOML11_COMMENTS_IMPL_HPP

--- a/include/toml11/impl/datetime_impl.hpp
+++ b/include/toml11/impl/datetime_impl.hpp
@@ -15,6 +15,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 
 // To avoid non-threadsafe std::localtime. In C11 (not C++11!), localtime_s is
 // provided in the absolutely same purpose, but C++11 is actually not compatible
@@ -514,5 +516,6 @@ TOML11_INLINE std::string to_string(const offset_datetime& dt)
     return oss.str();
 }
 
-}//toml
+} // TOML11_INLINE_VERSION_NAMESPACE
+} // toml
 #endif // TOML11_DATETIME_IMPL_HPP

--- a/include/toml11/impl/error_info_impl.hpp
+++ b/include/toml11/impl/error_info_impl.hpp
@@ -3,10 +3,13 @@
 
 #include "../fwd/error_info_fwd.hpp"
 #include "../fwd/color_fwd.hpp"
+#include "../version.hpp"
 
 #include <sstream>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 TOML11_INLINE std::string format_error(const std::string& errkind, const error_info& err)
@@ -71,5 +74,6 @@ TOML11_INLINE std::ostream& operator<<(std::ostream& os, const error_info& e)
     return os;
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_ERROR_INFO_IMPL_HPP

--- a/include/toml11/impl/format_impl.hpp
+++ b/include/toml11/impl/format_impl.hpp
@@ -9,6 +9,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 
 // toml types with serialization info
 
@@ -293,5 +295,6 @@ TOML11_INLINE bool operator!=(const table_format_info& lhs, const table_format_i
     return !(lhs == rhs);
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_FORMAT_IMPL_HPP

--- a/include/toml11/impl/literal_impl.hpp
+++ b/include/toml11/impl/literal_impl.hpp
@@ -4,8 +4,11 @@
 #include "../fwd/literal_fwd.hpp"
 #include "../parser.hpp"
 #include "../syntax.hpp"
+#include "../version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 namespace detail
@@ -170,5 +173,6 @@ operator"" _toml(const char8_t* str, std::size_t len)
 
 } // toml_literals
 } // literals
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_LITERAL_IMPL_HPP

--- a/include/toml11/impl/location_impl.hpp
+++ b/include/toml11/impl/location_impl.hpp
@@ -7,6 +7,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace detail
 {
 
@@ -205,5 +207,6 @@ count(const location& first, const location& last, const location::char_type& c)
 }
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_LOCATION_HPP

--- a/include/toml11/impl/region_impl.hpp
+++ b/include/toml11/impl/region_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "../fwd/region_fwd.hpp"
 #include "../utility.hpp"
+#include "../version.hpp"
 
 #include <algorithm>
 #include <iterator>
@@ -12,6 +13,8 @@
 #include <cassert>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -242,5 +245,6 @@ TOML11_INLINE std::vector<std::pair<std::string, std::size_t>> region::as_lines(
 }
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_REGION_IMPL_HPP

--- a/include/toml11/impl/scanner_impl.hpp
+++ b/include/toml11/impl/scanner_impl.hpp
@@ -3,8 +3,11 @@
 
 #include "../fwd/scanner_fwd.hpp"
 #include "../utility.hpp"
+#include "../version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -468,5 +471,6 @@ TOML11_INLINE std::string maybe::name() const
 }
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_SCANNER_IMPL_HPP

--- a/include/toml11/impl/source_location_impl.hpp
+++ b/include/toml11/impl/source_location_impl.hpp
@@ -5,6 +5,7 @@
 
 #include "../color.hpp"
 #include "../utility.hpp"
+#include "../version.hpp"
 
 #include <iomanip>
 #include <sstream>
@@ -14,6 +15,8 @@
 #include <cctype>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 TOML11_INLINE source_location::source_location(const detail::region& r)
@@ -207,5 +210,6 @@ TOML11_INLINE std::string format_location_impl(const std::size_t lnw,
 }
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_SOURCE_LOCATION_IMPL_HPP

--- a/include/toml11/impl/syntax_impl.hpp
+++ b/include/toml11/impl/syntax_impl.hpp
@@ -4,8 +4,11 @@
 #include "../fwd/syntax_fwd.hpp"
 #include "../scanner.hpp"
 #include "../spec.hpp"
+#include "../version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -885,5 +888,6 @@ TOML11_INLINE literal const& null_value(const spec&)
 
 } // namespace syntax
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_SYNTAX_IMPL_HPP

--- a/include/toml11/impl/value_t_impl.hpp
+++ b/include/toml11/impl/value_t_impl.hpp
@@ -2,12 +2,15 @@
 #define TOML11_VALUE_T_IMPL_HPP
 
 #include "../fwd/value_t_fwd.hpp"
+#include "../version.hpp"
 
 #include <ostream>
 #include <sstream>
 #include <string>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 TOML11_INLINE std::ostream& operator<<(std::ostream& os, value_t t)
@@ -36,5 +39,6 @@ TOML11_INLINE std::string to_string(value_t t)
     return oss.str();
 }
 
+} //TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_VALUE_T_IMPL_HPP

--- a/include/toml11/into.hpp
+++ b/include/toml11/into.hpp
@@ -1,7 +1,10 @@
 #ifndef TOML11_INTO_HPP
 #define TOML11_INTO_HPP
+#include "version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 template<typename T>
@@ -13,5 +16,6 @@ struct into;
 //     }
 // };
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_INTO_HPP

--- a/include/toml11/ordered_map.hpp
+++ b/include/toml11/ordered_map.hpp
@@ -6,7 +6,11 @@
 #include <utility>
 #include <vector>
 
+#include "version.hpp"
+
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 namespace detail
@@ -193,17 +197,17 @@ class ordered_map : detail::ordered_map_ebo_container<Cmp>
     {
         return container_.erase(pos);
     }
-    
+
     iterator erase(const_iterator pos)
     {
         return container_.erase(pos);
     }
-    
+
     iterator erase(const_iterator first, const_iterator last)
     {
         return container_.erase(first, last);
     }
-    
+
     size_type erase(const key_type& key)
     {
         auto it = this->find(key);
@@ -287,5 +291,6 @@ void swap(ordered_map<K,V,C,A>& lhs, ordered_map<K,V,C,A>& rhs)
 }
 
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_ORDERED_MAP_HPP

--- a/include/toml11/parser.hpp
+++ b/include/toml11/parser.hpp
@@ -10,6 +10,7 @@
 #include "skip.hpp"
 #include "syntax.hpp"
 #include "value.hpp"
+#include "version.hpp"
 
 #include <fstream>
 #include <sstream>
@@ -22,6 +23,8 @@
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 struct syntax_error final : public ::toml::exception
@@ -3786,10 +3789,13 @@ parse(FILE* fp, std::string filename, spec s = spec::default_version())
     }
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 
 #if defined(TOML11_COMPILE_SOURCES)
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 struct type_config;
 struct ordered_type_config;
@@ -3825,6 +3831,7 @@ extern template cxx::enable_if_t<std::is_same<std::filesystem::path, std::filesy
 extern template cxx::enable_if_t<std::is_same<std::filesystem::path, std::filesystem::path>::value, basic_value<ordered_type_config>                                 > parse    <ordered_type_config, std::filesystem::path>(const std::filesystem::path&, spec);
 #endif // filesystem
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COMPILE_SOURCES
 

--- a/include/toml11/result.hpp
+++ b/include/toml11/result.hpp
@@ -3,6 +3,7 @@
 
 #include "compat.hpp"
 #include "exception.hpp"
+#include "version.hpp"
 
 #include <ostream>
 #include <string>
@@ -12,6 +13,8 @@
 #include <cassert>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 struct bad_result_access final : public ::toml::exception
@@ -482,5 +485,6 @@ inline failure<detail::none_t> err() noexcept
     return failure<detail::none_t>(detail::none_t{});
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_RESULT_HPP

--- a/include/toml11/serializer.hpp
+++ b/include/toml11/serializer.hpp
@@ -10,6 +10,7 @@
 #include "types.hpp"
 #include "utility.hpp"
 #include "value.hpp"
+#include "version.hpp"
 
 #include <iomanip>
 #include <iterator>
@@ -19,6 +20,8 @@
 #include <cstdio>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 struct serialization_error final : public ::toml::exception
@@ -1233,10 +1236,13 @@ std::ostream& operator<<(std::ostream& os, const basic_value<TC>& v)
     return os;
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 #if defined(TOML11_COMPILE_SOURCES)
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 struct type_config;
 struct ordered_type_config;
@@ -1268,6 +1274,7 @@ namespace detail
 extern template class serializer<::toml::type_config>;
 extern template class serializer<::toml::ordered_type_config>;
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COMPILE_SOURCES
 

--- a/include/toml11/skip.hpp
+++ b/include/toml11/skip.hpp
@@ -6,10 +6,13 @@
 #include "scanner.hpp"
 #include "syntax.hpp"
 #include "types.hpp"
+#include "version.hpp"
 
 #include <cassert>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -353,10 +356,13 @@ void skip_until_next_table(location& loc, const context<TC>& ctx)
 }
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 
 #if defined(TOML11_COMPILE_SOURCES)
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 struct type_config;
 struct ordered_type_config;
@@ -386,6 +392,7 @@ extern template void skip_key_value_pair        <ordered_type_config>(location& 
 extern template void skip_until_next_table      <ordered_type_config>(location& loc, const context<ordered_type_config>&);
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COMPILE_SOURCES
 

--- a/include/toml11/spec.hpp
+++ b/include/toml11/spec.hpp
@@ -9,7 +9,11 @@
 
 #include <cstdint>
 
+#include "version.hpp"
+
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 struct semantic_version
@@ -165,5 +169,6 @@ inline bool operator>=(const spec& lhs, const spec& rhs) noexcept
     return detail::to_tuple(lhs) >= detail::to_tuple(rhs);
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_SPEC_HPP

--- a/include/toml11/storage.hpp
+++ b/include/toml11/storage.hpp
@@ -2,8 +2,11 @@
 #define TOML11_STORAGE_HPP
 
 #include "compat.hpp"
+#include "version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -45,5 +48,6 @@ struct storage
 };
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_STORAGE_HPP

--- a/include/toml11/traits.hpp
+++ b/include/toml11/traits.hpp
@@ -4,6 +4,7 @@
 #include "from.hpp"
 #include "into.hpp"
 #include "compat.hpp"
+#include "version.hpp"
 
 #include <array>
 #include <chrono>
@@ -23,6 +24,8 @@
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 template<typename TypeConcig>
 class basic_value;
@@ -262,5 +265,6 @@ template<typename T>
 using is_basic_value = is_basic_value_impl<cxx::remove_cvref_t<T>>;
 
 }// detail
-}//toml
+} // TOML11_INLINE_VERSION_NAMESPACE
+} // toml
 #endif // TOML11_TRAITS_HPP

--- a/include/toml11/types.hpp
+++ b/include/toml11/types.hpp
@@ -7,6 +7,7 @@
 #include "format.hpp"
 #include "ordered_map.hpp"
 #include "value.hpp"
+#include "version.hpp"
 
 #include <ostream>
 #include <sstream>
@@ -19,6 +20,8 @@
 #include <cstdio>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 // forward decl
@@ -361,13 +364,17 @@ using is_type_config = cxx::conjunction<
     >;
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 
 #if defined(TOML11_COMPILE_SOURCES)
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 extern template class basic_value<type_config>;
 extern template class basic_value<ordered_type_config>;
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_COMPILE_SOURCES
 

--- a/include/toml11/utility.hpp
+++ b/include/toml11/utility.hpp
@@ -3,6 +3,7 @@
 
 #include "result.hpp"
 #include "traits.hpp"
+#include "version.hpp"
 
 #include <array>
 #include <sstream>
@@ -12,6 +13,8 @@
 #include <cstring>
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 namespace detail
 {
@@ -166,5 +169,6 @@ string_conv(const char (&s)[N])
 }
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_UTILITY_HPP

--- a/include/toml11/value.hpp
+++ b/include/toml11/value.hpp
@@ -25,6 +25,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 template<typename TypeConfig>
 class basic_value;
 
@@ -2506,5 +2508,6 @@ void unset_access_flag_recursively(basic_value<TC>& v)
 #endif
 
 } // namespace detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // namespace toml
 #endif // TOML11_VALUE_HPP

--- a/include/toml11/version.hpp
+++ b/include/toml11/version.hpp
@@ -9,6 +9,25 @@
 #    error "__cplusplus is not defined"
 #endif
 
+/*
+ * Defines a name for an inline namespace that includes the current version
+ * number. This becomes necessary if multiple software packages use toml11 as an
+ * internal build-time dependency, since multiple packages will in general not
+ * use the same version of toml11. An inline namespace with a version number
+ * ensures that the symbols emitted by compiling toml11 into downstream
+ * applications will be distinguished by the specific used version of toml11,
+ * making it possible to link multiple packages that internally use toml11 in
+ * different versions.
+ */
+#define TOML11_CONCAT(a, b, c, d, e, f) a##b##c##d##e##f
+
+#define TOML11_GENERATE_INLINE_VERSION_NAMESPACE(major, minor, patch)          \
+    TOML11_CONCAT(toml11_, major, _, minor, _, patch)
+
+#define TOML11_INLINE_VERSION_NAMESPACE                                        \
+    TOML11_GENERATE_INLINE_VERSION_NAMESPACE(                                  \
+        TOML11_VERSION_MAJOR, TOML11_VERSION_MINOR, TOML11_VERSION_PATCH)
+
 // Since MSVC does not define `__cplusplus` correctly unless you pass
 // `/Zc:__cplusplus` when compiling, the workaround macros are added.
 //
@@ -91,6 +110,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 
 inline const char* license_notice() noexcept
 {
@@ -117,5 +138,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.)";
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_VERSION_HPP

--- a/include/toml11/visit.hpp
+++ b/include/toml11/visit.hpp
@@ -4,8 +4,11 @@
 #include "exception.hpp"
 #include "traits.hpp"
 #include "value.hpp"
+#include "version.hpp"
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 namespace detail
@@ -132,5 +135,6 @@ visit(Visitor&& visitor, Args&& ... args)
     return detail::visit_impl(std::forward<Visitor>(visitor), std::forward<Args>(args)...);
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif // TOML11_VISIT_HPP

--- a/include/toml_fwd.hpp
+++ b/include/toml_fwd.hpp
@@ -19,6 +19,8 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 class discard_comments;
 class preserve_comments;
 
@@ -84,5 +86,6 @@ using ordered_value = basic_value<ordered_type_config>;
 
 enum class value_t : std::uint8_t;
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif// TOML11_TOML_HPP

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,5 +1,6 @@
 #include <toml11/context.hpp>
 #include <toml11/types.hpp>
+#include <toml11/version.hpp>
 
 #if ! defined(TOML11_COMPILE_SOURCES)
 #error "Define `TOML11_COMPILE_SOURCES` before compiling source code!"
@@ -7,9 +8,12 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace detail
 {
 template class context<::toml::type_config>;
 template class context<::toml::ordered_type_config>;
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,11 +1,14 @@
 #include <toml11/parser.hpp>
 #include <toml11/types.hpp>
+#include <toml11/version.hpp>
 
 #if ! defined(TOML11_COMPILE_SOURCES)
 #error "Define `TOML11_COMPILE_SOURCES` before compiling source code!"
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 template result<basic_value<type_config>, std::vector<error_info>> try_parse<type_config>(std::vector<unsigned char>, std::string, spec);
@@ -39,4 +42,5 @@ template cxx::enable_if_t<std::is_same<std::filesystem::path, std::filesystem::p
 template cxx::enable_if_t<std::is_same<std::filesystem::path, std::filesystem::path>::value, basic_value<ordered_type_config>                                 > parse    <ordered_type_config, std::filesystem::path>(const std::filesystem::path&, spec);
 #endif // filesystem
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -1,11 +1,14 @@
 #include <toml11/serializer.hpp>
 #include <toml11/types.hpp>
+#include <toml11/version.hpp>
 
 #if ! defined(TOML11_COMPILE_SOURCES)
 #error "Define `TOML11_COMPILE_SOURCES` before compiling source code!"
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 struct type_config;
 struct ordered_type_config;
@@ -37,4 +40,5 @@ namespace detail
 template class serializer<::toml::type_config>;
 template class serializer<::toml::ordered_type_config>;
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml

--- a/src/skip.cpp
+++ b/src/skip.cpp
@@ -1,12 +1,15 @@
 #include <toml11/parser.hpp>
 #include <toml11/skip.hpp>
 #include <toml11/types.hpp>
+#include <toml11/version.hpp>
 
 #if ! defined(TOML11_COMPILE_SOURCES)
 #error "Define `TOML11_COMPILE_SOURCES` before compiling source code!"
 #endif
 
 namespace toml
+{
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
 {
 
 namespace detail
@@ -34,4 +37,5 @@ template void skip_key_value_pair        <ordered_type_config>(location& loc, co
 template void skip_until_next_table      <ordered_type_config>(location& loc, const context<ordered_type_config>&);
 
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,5 +1,6 @@
 #include <toml11/value.hpp>
 #include <toml11/types.hpp>
+#include <toml11/version.hpp>
 
 #if ! defined(TOML11_COMPILE_SOURCES)
 #error "Define `TOML11_COMPILE_SOURCES` before compiling source code!"
@@ -7,6 +8,9 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 template class basic_value<type_config>;
 template class basic_value<ordered_type_config>;
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml

--- a/tests/test_find.cpp
+++ b/tests/test_find.cpp
@@ -19,11 +19,14 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace detail
 {
 std::tm localtime_s(const std::time_t* src);
 std::tm gmtime_s(const std::time_t* src);
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 TEST_CASE("testing toml::find with toml type")

--- a/tests/test_get.cpp
+++ b/tests/test_get.cpp
@@ -19,11 +19,14 @@
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 namespace detail
 {
 std::tm localtime_s(const std::time_t* src);
 std::tm gmtime_s(const std::time_t* src);
 } // detail
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 TEST_CASE("testing toml::get with toml types")

--- a/tests/test_user_defined_conversion.cpp
+++ b/tests/test_user_defined_conversion.cpp
@@ -76,6 +76,8 @@ struct corge
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 template<>
 struct from<extlib::foo>
 {
@@ -113,6 +115,7 @@ struct into<extlib::qux>
         return toml::basic_value<TC>(typename toml::basic_value<TC>::table_type{{"a", f.a}, {"b", f.b}});
     }
 };
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------
@@ -167,6 +170,8 @@ struct foobar
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 template<>
 struct from<extlib2::foo>
 {
@@ -209,6 +214,7 @@ struct into<extlib2::qux>
         };
     }
 };
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 
 // ---------------------------------------------------------------------------

--- a/tests/utility.cpp
+++ b/tests/utility.cpp
@@ -25,6 +25,8 @@ void test_scan_failure(const toml::detail::scanner_base& s,
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 
 std::ostream& operator<<(std::ostream& os, const integer_format_info& fmt)
 {
@@ -102,4 +104,5 @@ std::ostream& operator<<(std::ostream& os, const table_format_info& fmt)
     return os;
 }
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml

--- a/tests/utility.hpp
+++ b/tests/utility.hpp
@@ -86,6 +86,8 @@ void toml11_test_parse_failure(F fn, std::string in, toml::detail::context<TC> c
 
 namespace toml
 {
+inline namespace TOML11_INLINE_VERSION_NAMESPACE
+{
 std::ostream& operator<<(std::ostream& os, const integer_format_info&);
 std::ostream& operator<<(std::ostream& os, const floating_format_info&);
 std::ostream& operator<<(std::ostream& os, const string_format_info&);
@@ -96,5 +98,6 @@ std::ostream& operator<<(std::ostream& os, const local_time_format_info&);
 std::ostream& operator<<(std::ostream& os, const array_format_info&);
 std::ostream& operator<<(std::ostream& os, const table_format_info&);
 
+} // TOML11_INLINE_VERSION_NAMESPACE
 } // toml
 #endif// TOML11_TEST_UTILITY_HPP


### PR DESCRIPTION
This is a trick commonly used to ensure that header-only C++ libraries which are used only internally at build-time do not emit conflicting symbols if the library is used in multiple packages, possibly in different version numbers (see e.g. the STL).

With this PR, the symbols produced by toml11 in downstream code contain the library's current version number:
```
> nm -gDC libopenPMD.so | grep -i toml | head -n 10
00000000005908b8 u guard variable for toml::toml11_3_8_1::color_ansi::detail::colorize_index()::index
0000000000590888 u guard variable for toml::toml11_3_8_1::detail::comment_index<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&)::index
0000000000335860 W toml::toml11_3_8_1::color_ansi::blue(std::ostream&)
0000000000335780 W toml::toml11_3_8_1::color_ansi::bold(std::ostream&)
00000000003356a0 W toml::toml11_3_8_1::color_ansi::reset(std::ostream&)
00000000003800e0 W std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > toml::toml11_3_8_1::format_key<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
0000000000336fe0 W toml::toml11_3_8_1::type_error::type_error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, toml::toml11_3_8_1::source_location const&)
0000000000336fe0 W toml::toml11_3_8_1::type_error::type_error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, toml::toml11_3_8_1::source_location const&)
0000000000334940 W toml::toml11_3_8_1::type_error::~type_error()
0000000000334610 W toml::toml11_3_8_1::type_error::~type_error()
```

This avoids conflicts when trying to link two packages that both internally use toml11 in conflicting versions.
The `inline namespace` ensures that application programmers do not need to change any code since the effect of inline namespaces is only on the ABI, not on the API.

Note: I will not be able to respond next week. Feel free to modify the PR as needed.

TODO:

- [x] Seems like I started this on the wrong branch, will need to reapply the changes
- [x] Fix the tests
- [ ] `examples/reflect/reflect.hpp`: While this PR is generally not API-breaking, it probably *does* break the API for use in reflection. I could simply apply the necessary change there too, but I do not know the consequences that this would have on user code.