### PR TITLE
Add a way to optionally suppress usage of std::source_location

### DIFF
--- a/include/toml11/compat.hpp
+++ b/include/toml11/compat.hpp
@@ -448,13 +448,13 @@ using void_t = void;
 // ----------------------------------------------------------------------------
 // (subset of) source_location
 
-#if TOML11_CPLUSPLUS_STANDARD_VERSION >= 202002L
+#if ! defined(TOML11_DISABLE_SOURCE_LOCATION) && TOML11_CPLUSPLUS_STANDARD_VERSION >= 202002L
 #  if __has_include(<source_location>)
 #    define TOML11_HAS_STD_SOURCE_LOCATION
 #  endif // has_include
 #endif // c++20
 
-#if ! defined(TOML11_HAS_STD_SOURCE_LOCATION)
+#if ! defined(TOML11_DISABLE_SOURCE_LOCATION) && ! defined(TOML11_HAS_STD_SOURCE_LOCATION)
 #  if defined(__GNUC__) && ! defined(__clang__)
 #    if TOML11_CPLUSPLUS_STANDARD_VERSION >= TOML11_CXX14_VALUE
 #      if __has_include(<experimental/source_location>)
@@ -464,7 +464,7 @@ using void_t = void;
 #  endif // GNU g++
 #endif // not TOML11_HAS_STD_SOURCE_LOCATION
 
-#if ! defined(TOML11_HAS_STD_SOURCE_LOCATION) && ! defined(TOML11_HAS_EXPERIMENTAL_SOURCE_LOCATION)
+#if ! defined(TOML11_DISABLE_SOURCE_LOCATION) && ! defined(TOML11_HAS_STD_SOURCE_LOCATION) && ! defined(TOML11_HAS_EXPERIMENTAL_SOURCE_LOCATION)
 #  if defined(__GNUC__) && ! defined(__clang__)
 #    if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))
 #      define TOML11_HAS_BUILTIN_FILE_LINE 1


### PR DESCRIPTION
The integrated checks for availability of `std::source_location` seem to not work correctly for Clang++ 11-13, compare this output from [our failing CI](https://gitlab.com/hzdr/crp/picongpu/-/pipelines/1864855034):

```
[ 42%] Building CXX object CMakeFiles/picongpu-hostonly.dir/plugins/openPMD/toml.cpp.o
In file included from /builds/hzdr/crp/picongpu/include/picongpu/plugins/openPMD/toml.cpp:38:
In file included from /builds/hzdr/crp/picongpu/thirdParty/toml11/include/toml.hpp:29:
/builds/hzdr/crp/picongpu/thirdParty/toml11/include/toml11/compat.hpp:494:30: error: no type named 'source_location' in namespace 'std'
using source_location = std::source_location;
```

This PR adds a way to suppress usage of `std::source_location`:

```cpp
#define TOML11_DISABLE_SOURCE_LOCATION
#include <toml.hpp>
```